### PR TITLE
Fix algebra

### DIFF
--- a/core/jvm/src/main/scala/hammock/jvm/free/Interpreter.scala
+++ b/core/jvm/src/main/scala/hammock/jvm/free/Interpreter.scala
@@ -23,13 +23,13 @@ class Interpreter(client: HttpClient) extends InterpTrans {
   override def trans[F[_]](implicit ME: MonadError[F, Throwable]) = transK andThen λ[Kleisli[F, HttpClient, ?] ~> F](_.run(client))
 
   def transK[F[_]](implicit ME: MonadError[F, Throwable]): HttpRequestF ~> Kleisli[F, HttpClient, ?] = λ[HttpRequestF ~> Kleisli[F, HttpClient, ?]](_ match {
-    case req@Options(url, headers, body) => doReq(req)
-    case req@Get(url, headers, body) => doReq(req)
-    case req@Head(url, headers, body) => doReq(req)
+    case req@Options(url, headers) => doReq(req)
+    case req@Get(url, headers) => doReq(req)
+    case req@Head(url, headers) => doReq(req)
     case req@Post(url, headers, body) => doReq(req)
     case req@Put(url, headers, body) => doReq(req)
-    case req@Delete(url, headers, body) => doReq(req)
-    case req@Trace(url, headers, body) => doReq(req)
+    case req@Delete(url, headers) => doReq(req)
+    case req@Trace(url, headers) => doReq(req)
   })
 
   private def doReq[F[_]](reqF: HttpRequestF[HttpResponse])(implicit ME: MonadError[F, Throwable]): Kleisli[F, HttpClient, HttpResponse] = Kleisli { client =>
@@ -50,15 +50,18 @@ class Interpreter(client: HttpClient) extends InterpTrans {
   }
 
   private def getApacheRequest(f: HttpRequestF[HttpResponse]): HttpUriRequest = f match {
-    case Get(url, headers, body) =>
+    case Get(url, headers) =>
       val req = new HttpGet(url)
       req.setHeaders(prepareHeaders(headers))
       req
-    case Options(url, headers, body) =>
+    case Options(url, headers) =>
       val req = new HttpOptions(url)
       req.setHeaders(prepareHeaders(headers))
       req
-    case Head(url, headers, body) => new HttpHead(url)
+    case Head(url, headers) =>
+      val req = new HttpHead(url)
+      req.setHeaders(prepareHeaders(headers))
+      req
     case Post(url, headers, body) =>
       val req = new HttpPost(url)
       req.setHeaders(prepareHeaders(headers))
@@ -69,11 +72,11 @@ class Interpreter(client: HttpClient) extends InterpTrans {
       req.setHeaders(prepareHeaders(headers))
       body foreach (b => req.setEntity(new StringEntity(b)))
       req
-    case Delete(url, headers, body) =>
+    case Delete(url, headers) =>
       val req = new HttpDelete(url)
       req.setHeaders(prepareHeaders(headers))
       req
-    case Trace(url, headers, body) =>
+    case Trace(url, headers) =>
       val req = new HttpTrace(url)
       req.setHeaders(prepareHeaders(headers))
       req

--- a/core/jvm/src/test/scala/hammock/jvm/free/InterpreterSpec.scala
+++ b/core/jvm/src/test/scala/hammock/jvm/free/InterpreterSpec.scala
@@ -33,19 +33,19 @@ class InterpreterSpec extends WordSpec with MockitoSugar with BeforeAndAfter {
 
   "Interpreter.trans" should {
     val methods = Seq(
-      ("Options", Ops.options _),
-      ("Get", Ops.get _),
-      ("Head", Ops.head _),
-      ("Post", Ops.post _),
-      ("Put", Ops.put _),
-      ("Delete", Ops.delete _),
-      ("Trace", Ops.trace _)
+      ("Options", (url: String, headers: Map[String, String]) => Ops.options(url, headers)),
+      ("Get", (url: String, headers: Map[String, String]) => Ops.get(url, headers)),
+      ("Head", (url: String, headers: Map[String, String]) => Ops.head(url, headers)),
+      ("Post", (url: String, headers: Map[String, String]) => Ops.post(url, headers, None)),
+      ("Put", (url: String, headers: Map[String, String]) => Ops.put(url, headers, None)),
+      ("Delete", (url: String, headers: Map[String, String]) => Ops.delete(url, headers)),
+      ("Trace", (url: String, headers: Map[String, String]) => Ops.trace(url, headers))
     ) map {
       case (method, operation)=>
       s"have the same result as transK.run(client) with $method requests" in {
         when(client.execute(any())).thenReturn(httpResponse)
 
-        val op = operation("", Map(), None)
+        val op = operation("", Map())
 
         val k = op foldMap[Kleisli[Try, HttpClient, ?]] interp.transK[Try]
 
@@ -60,7 +60,7 @@ class InterpreterSpec extends WordSpec with MockitoSugar with BeforeAndAfter {
     "create a correct HttpResponse from Apache's HTTP response" in {
       when(client.execute(any())).thenReturn(httpResponse)
 
-      val op = Ops.get("", Map(), None)
+      val op = Ops.get("", Map())
 
       val k = op foldMap[Kleisli[Try, HttpClient, ?]] interp.transK[Try]
 

--- a/core/shared/src/main/scala/hammock/Hammock.scala
+++ b/core/shared/src/main/scala/hammock/Hammock.scala
@@ -11,23 +11,23 @@ import hi.Opts
 object Hammock {
 
   def request(method: Method, url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = method match {
-    case Method.OPTIONS => Ops.options(url, headers, None)
-    case Method.GET => Ops.get(url, headers, None)
-    case Method.HEAD => Ops.head(url, headers, None)
+    case Method.OPTIONS => Ops.options(url, headers)
+    case Method.GET => Ops.get(url, headers)
+    case Method.HEAD => Ops.head(url, headers)
     case Method.POST => Ops.post(url, headers, None)
     case Method.PUT => Ops.put(url, headers, None)
-    case Method.DELETE => Ops.delete(url, headers, None)
-    case Method.TRACE => Ops.trace(url, headers, None)
+    case Method.DELETE => Ops.delete(url, headers)
+    case Method.TRACE => Ops.trace(url, headers)
   }
 
   def request[A : Codec](method: Method, url: String, headers: Map[String, String], body: Option[A]): HttpRequestIO[HttpResponse] = method match {
-    case Method.OPTIONS => Ops.options(url, headers, body.map(Codec[A].encode))
-    case Method.GET => Ops.get(url, headers, body.map(Codec[A].encode))
-    case Method.HEAD => Ops.head(url, headers, body.map(Codec[A].encode))
+    case Method.OPTIONS => Ops.options(url, headers)
+    case Method.GET => Ops.get(url, headers)
+    case Method.HEAD => Ops.head(url, headers)
     case Method.POST => Ops.post(url, headers, body.map(Codec[A].encode))
     case Method.PUT => Ops.put(url, headers, body.map(Codec[A].encode))
-    case Method.DELETE => Ops.delete(url, headers, body.map(Codec[A].encode))
-    case Method.TRACE => Ops.trace(url, headers, body.map(Codec[A].encode))
+    case Method.DELETE => Ops.delete(url, headers)
+    case Method.TRACE => Ops.trace(url, headers)
   }
 
   def withOpts(method: Method, url: String, opts: Opts): HttpRequestIO[HttpResponse] = {

--- a/core/shared/src/main/scala/hammock/free/algebra.scala
+++ b/core/shared/src/main/scala/hammock/free/algebra.scala
@@ -6,39 +6,60 @@ import cats.free._
 
 object algebra {
 
-  sealed abstract class HttpRequestF[A] extends Product with Serializable {
+  sealed trait HttpRequestF[A] extends Product with Serializable {
+    def method: Method
     def url: String
     def headers: Map[String, String]
     def body: Option[String]
   }
-  final case class Options(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse]
-  final case class Get(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse]
-  final case class Head(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse]
-  final case class Post(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse]
-  final case class Put(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse]
-  final case class Delete(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse]
-  final case class Trace(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse]
+
+  final case class Options(url: String, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
+    def body = None
+    def method = Method.OPTIONS
+  }
+  final case class Get(url: String, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
+    def body = None
+    def method = Method.GET
+  }
+  final case class Head(url: String, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
+    def body = None
+    def method = Method.HEAD
+  }
+  final case class Post(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse] {
+    def method = Method.POST
+  }
+  final case class Put(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse] {
+    def method = Method.PUT
+  }
+  final case class Delete(url: String, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
+    def body = None
+    def method = Method.DELETE
+  }
+  final case class Trace(url: String, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
+    def body = None
+    def method = Method.TRACE
+  }
 
   type HttpRequestIO[A] = Free[HttpRequestF, A]
 
   object Ops {
-    def options(url: String, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Options(url, headers, body))
-    def get(url: String, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Get(url, headers, body))
-    def head(url: String, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Head(url, headers, body))
+    def options(url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Options(url, headers))
+    def get(url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Get(url, headers))
+    def head(url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Head(url, headers))
     def post(url: String, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Post(url, headers, body))
     def put(url: String, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Put(url, headers, body))
-    def delete(url: String, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Delete(url, headers, body))
-    def trace(url: String, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Trace(url, headers, body))
+    def delete(url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Delete(url, headers))
+    def trace(url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Trace(url, headers))
   }
 
   class HttpRequestC[F[_]](implicit I: Inject[HttpRequestF, F]) {
-    def options(url: String, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Options(url, headers, body))
-    def get(url: String, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Get(url, headers, body))
-    def head(url: String, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Head(url, headers, body))
+    def options(url: String, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Options(url, headers))
+    def get(url: String, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Get(url, headers))
+    def head(url: String, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Head(url, headers))
     def post(url: String, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Post(url, headers, body))
     def put(url: String, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Put(url, headers, body))
-    def delete(url: String, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Delete(url, headers, body))
-    def trace(url: String, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Trace(url, headers, body))
+    def delete(url: String, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Delete(url, headers))
+    def trace(url: String, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Trace(url, headers))
   }
 
   object HttpRequestC {

--- a/core/shared/src/test/scala/hammock/HammockSpec.scala
+++ b/core/shared/src/test/scala/hammock/HammockSpec.scala
@@ -42,11 +42,11 @@ class HammockSpec extends WordSpec with Matchers {
       }
 
       s"create a valid $method request with a body" in {
-        val body = Some("body!!")
+        val body = None
         Hammock.request(method, "http://pepegar.com", Map(), body) foldMap test { r =>
           r.url shouldEqual "http://pepegar.com"
           r.headers shouldEqual Map()
-          r.body shouldEqual Some("body!!")
+          r.body shouldEqual None
         }
       }
     }

--- a/docs/src/main/tut/docs.md
+++ b/docs/src/main/tut/docs.md
@@ -137,7 +137,7 @@ object App {
     _ <- IO.write("What's the ID?")
     id = "4" // for the sake of docs, lets hardcode this... It should be `id <- IO.read`
     _ <- Log.info(s"id was $id")
-    response <- Hammock.get(s"https://jsonplaceholder.typicode.com/users?id=$id", Map(), None)
+    response <- Hammock.get(s"https://jsonplaceholder.typicode.com/users?id=$id", Map())
   } yield response
 
   def interp1[F[_]](implicit ME: MonadError[F, Throwable]): Eff1 ~> F = Log.interp(ME) or IO.interp(ME)


### PR DESCRIPTION
We need to make some design changes to the algebra.

Even though the spec does not specifically specify that for example, a `GET` request SHALL NOT have a body, most clients does not allow that.

We've changed the algebra and now, only `POST` and `PUT` requests are allowed to have a body. This is also more aligned with the _restfulness_ orientation of the project.