### PR TITLE
add uri model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ organization in ThisBuild := "com.pepegar"
 scalaVersion in ThisBuild := "2.11.8"
 licenses in ThisBuild := Seq(("MIT", url("http://opensource.org/licenses/MIT")))
 
+resolvers in ThisBuild += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+
 val scalaVersions = Seq("2.11.8", "2.12.0")
 
 val circeVersion = "0.6.1"
@@ -15,7 +17,7 @@ val micrositeSettings = Seq(
   micrositeHighlightTheme := "tomorrow"
 )
 val monocleVersion = "1.4.0"
-val attoVersion = "0.5.1"
+val attoVersion = "0.5.2-SNAPSHOT"
 
 val commonSettings = Seq(
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -15,12 +15,15 @@ val micrositeSettings = Seq(
   micrositeHighlightTheme := "tomorrow"
 )
 val monocleVersion = "1.4.0"
+val attoVersion = "0.5.1"
 
 val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats" % "0.8.1",
     "com.github.julien-truffaut" %%  "monocle-core"  % monocleVersion,
     "com.github.julien-truffaut" %%  "monocle-macro" % monocleVersion,
+    "org.tpolecat" %% "atto-core" % attoVersion,
+    "org.tpolecat" %% "atto-compat-cats" % attoVersion,
 
     compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3"),
@@ -65,6 +68,7 @@ lazy val core = crossProject.in(file("core"))
   libraryDependencies ++= Seq(
     "org.apache.httpcomponents" % "httpclient" % "4.5.2",
     "org.mockito" % "mockito-all" % "1.10.18" % "test"
+
   ),
     crossScalaVersions := scalaVersions
   )

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val commonSettings = Seq(
     "com.github.julien-truffaut" %%  "monocle-macro" % monocleVersion,
     "org.tpolecat" %% "atto-core" % attoVersion,
     "org.tpolecat" %% "atto-compat-cats" % attoVersion,
-
+    "com.propensive" %% "contextual" % "1.0.0",
     compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3"),
     "org.scalatest" %% "scalatest" % "3.0.1" % "test",
@@ -68,7 +68,6 @@ lazy val core = crossProject.in(file("core"))
   libraryDependencies ++= Seq(
     "org.apache.httpcomponents" % "httpclient" % "4.5.2",
     "org.mockito" % "mockito-all" % "1.10.18" % "test"
-
   ),
     crossScalaVersions := scalaVersions
   )

--- a/core/js/src/main/scala/hammock/js/free/Interpreter.scala
+++ b/core/js/src/main/scala/hammock/js/free/Interpreter.scala
@@ -8,9 +8,11 @@ import org.scalajs.dom
 
 import cats._
 import cats.data._
+import cats.syntax.show._
 
 object Interpreter extends InterpTrans {
 
+  import Uri._
   import algebra._
 
   override def trans[F[_]](implicit ME: MonadError[F, Throwable]): HttpRequestF ~> F = λ[HttpRequestF ~> F](_ match {
@@ -27,7 +29,7 @@ object Interpreter extends InterpTrans {
     val xhr = new dom.XMLHttpRequest()
     val async = false // asynchronicity should be handled by the concurrency monad `F`, not the HTTP driver
 
-    xhr.open(method.name, req.url, async)
+    xhr.open(method.name, req.uri.show, async)
     req.headers foreach {
       case (k, v) => xhr.setRequestHeader(k, v)
     }

--- a/core/jvm/src/test/scala/hammock/jvm/free/InterpreterSpec.scala
+++ b/core/jvm/src/test/scala/hammock/jvm/free/InterpreterSpec.scala
@@ -33,19 +33,19 @@ class InterpreterSpec extends WordSpec with MockitoSugar with BeforeAndAfter {
 
   "Interpreter.trans" should {
     val methods = Seq(
-      ("Options", (url: String, headers: Map[String, String]) => Ops.options(url, headers)),
-      ("Get", (url: String, headers: Map[String, String]) => Ops.get(url, headers)),
-      ("Head", (url: String, headers: Map[String, String]) => Ops.head(url, headers)),
-      ("Post", (url: String, headers: Map[String, String]) => Ops.post(url, headers, None)),
-      ("Put", (url: String, headers: Map[String, String]) => Ops.put(url, headers, None)),
-      ("Delete", (url: String, headers: Map[String, String]) => Ops.delete(url, headers)),
-      ("Trace", (url: String, headers: Map[String, String]) => Ops.trace(url, headers))
+      ("Options", (uri: Uri, headers: Map[String, String]) => Ops.options(uri, headers)),
+      ("Get", (uri: Uri, headers: Map[String, String]) => Ops.get(uri, headers)),
+      ("Head", (uri: Uri, headers: Map[String, String]) => Ops.head(uri, headers)),
+      ("Post", (uri: Uri, headers: Map[String, String]) => Ops.post(uri, headers, None)),
+      ("Put", (uri: Uri, headers: Map[String, String]) => Ops.put(uri, headers, None)),
+      ("Delete", (uri: Uri, headers: Map[String, String]) => Ops.delete(uri, headers)),
+      ("Trace", (uri: Uri, headers: Map[String, String]) => Ops.trace(uri, headers))
     ) map {
       case (method, operation)=>
       s"have the same result as transK.run(client) with $method requests" in {
         when(client.execute(any())).thenReturn(httpResponse)
 
-        val op = operation("", Map())
+        val op = operation(Uri(path=""), Map())
 
         val k = op foldMap[Kleisli[Try, HttpClient, ?]] interp.transK[Try]
 
@@ -60,7 +60,7 @@ class InterpreterSpec extends WordSpec with MockitoSugar with BeforeAndAfter {
     "create a correct HttpResponse from Apache's HTTP response" in {
       when(client.execute(any())).thenReturn(httpResponse)
 
-      val op = Ops.get("", Map())
+      val op = Ops.get(Uri(path=""), Map())
 
       val k = op foldMap[Kleisli[Try, HttpClient, ?]] interp.transK[Try]
 

--- a/core/shared/src/main/scala/hammock/Uri.scala
+++ b/core/shared/src/main/scala/hammock/Uri.scala
@@ -70,7 +70,9 @@ object Uri {
   }
 
   /**
-    * String context allowing compile-time uri parsing.
+    * Unsafe string interpolator allowing uri parsing.  It's unsafe
+    * because in case of any error happen (a Left is returned by the
+    * `fromString` method), throw an exception.
     *
     * {{{
     * scala> uri"http://user:pass@pepegar.com/path?page=4#index"

--- a/core/shared/src/main/scala/hammock/Uri.scala
+++ b/core/shared/src/main/scala/hammock/Uri.scala
@@ -56,9 +56,14 @@ object Uri {
 
   def isValid(str: String): Boolean = fromString(str).isRight
 
+  object UriContext extends Context
+
   object UriInterpolator extends Interpolator {
+    type Context = UriContext.type
+    type Input = String
     def contextualize(interpolation: StaticInterpolation) = {
       val lit@Literal(_, uriString) = interpolation.parts.head
+
       if(!isValid(uriString))
         interpolation.abort(lit, 0, "not a valid URL")
 
@@ -69,10 +74,12 @@ object Uri {
       Uri.fromString(interpolation.literals.head).right.get
   }
 
+  implicit val embedString = UriInterpolator.embed[String](Case(UriContext, UriContext){x => x})
+
   /**
     * Unsafe string interpolator allowing uri parsing.  It's unsafe
     * because in case of any error happen (a Left is returned by the
-    * `fromString` method), throw an exception.
+    * `fromString` method), it will throw an exception.
     *
     * {{{
     * scala> uri"http://user:pass@pepegar.com/path?page=4#index"

--- a/core/shared/src/main/scala/hammock/Uri.scala
+++ b/core/shared/src/main/scala/hammock/Uri.scala
@@ -1,0 +1,56 @@
+package hammock
+
+
+import atto._
+import atto.compat.cats._
+import Atto._
+
+import cats._
+import cats.implicits._
+
+import Uri._
+
+case class Uri(
+  scheme: Option[Scheme] = None,
+  authority: Option[Authority] = None,
+  path: String = "",
+  query: Map[String, String] = Map(),
+  fragment: Option[Fragment] = None
+)
+
+object Uri {
+  type Error = String
+  type Authority = String
+  type Scheme = String
+  type Fragment = String
+
+  implicit val semigroup = new Semigroup[Uri] {
+    def combine(x: Uri,y: Uri): Uri = ???
+  }
+
+  implicit val show = new Show[Uri] {
+    override def show(u: Uri): String = u.scheme.fold("")(_ ++ "://") ++
+      u.authority.fold("")(_ ++ "@") ++
+      u.path ++ "?" ++
+      u.query.map(kv => s"${kv._1}=${kv._2}").mkString("&") ++
+      u.fragment.fold("")("#" ++ _)
+  }
+
+  def queryParam: Parser[(String, String)] = (stringOf(notChar('=')) <~ char('=')) ~ takeWhile(x => x != '&' && x != '#')
+
+  def queryParams: Parser[Map[String, String]] = sepBy(queryParam, char('&')).map(_.toMap)
+
+  def scheme: Parser[String] = takeWhile(_ != ':') <~ string("://")
+
+  def authority: Parser[String] = takeWhile(_ != '@') <~ char('@')
+
+  def parser: Parser[Uri] = for {
+    scheme <- opt(scheme)
+    authority <- opt(authority)
+    path <- takeWhile(x => x != '?' && x != '#')
+    queryParams <- opt(char('?') ~> queryParams)
+    fragment <- opt(char('#') ~> stringOf(anyChar))
+  } yield Uri(scheme, authority, path, queryParams.getOrElse(Map()), fragment)
+
+  def fromString(str: String): Either[Error, Uri] = (parser parseOnly str).either
+}

--- a/core/shared/src/main/scala/hammock/free/algebra.scala
+++ b/core/shared/src/main/scala/hammock/free/algebra.scala
@@ -8,34 +8,34 @@ object algebra {
 
   sealed trait HttpRequestF[A] extends Product with Serializable {
     def method: Method
-    def url: String
+    def uri: Uri
     def headers: Map[String, String]
     def body: Option[String]
   }
 
-  final case class Options(url: String, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
+  final case class Options(uri: Uri, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
     def body = None
     def method = Method.OPTIONS
   }
-  final case class Get(url: String, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
+  final case class Get(uri: Uri, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
     def body = None
     def method = Method.GET
   }
-  final case class Head(url: String, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
+  final case class Head(uri: Uri, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
     def body = None
     def method = Method.HEAD
   }
-  final case class Post(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse] {
+  final case class Post(uri: Uri, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse] {
     def method = Method.POST
   }
-  final case class Put(url: String, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse] {
+  final case class Put(uri: Uri, headers: Map[String, String], body: Option[String]) extends HttpRequestF[HttpResponse] {
     def method = Method.PUT
   }
-  final case class Delete(url: String, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
+  final case class Delete(uri: Uri, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
     def body = None
     def method = Method.DELETE
   }
-  final case class Trace(url: String, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
+  final case class Trace(uri: Uri, headers: Map[String, String]) extends HttpRequestF[HttpResponse] {
     def body = None
     def method = Method.TRACE
   }
@@ -43,23 +43,23 @@ object algebra {
   type HttpRequestIO[A] = Free[HttpRequestF, A]
 
   object Ops {
-    def options(url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Options(url, headers))
-    def get(url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Get(url, headers))
-    def head(url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Head(url, headers))
-    def post(url: String, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Post(url, headers, body))
-    def put(url: String, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Put(url, headers, body))
-    def delete(url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Delete(url, headers))
-    def trace(url: String, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Trace(url, headers))
+    def options(uri: Uri, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Options(uri, headers))
+    def get(uri: Uri, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Get(uri, headers))
+    def head(uri: Uri, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Head(uri, headers))
+    def post(uri: Uri, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Post(uri, headers, body))
+    def put(uri: Uri, headers: Map[String, String], body: Option[String]): HttpRequestIO[HttpResponse] = Free.liftF(Put(uri, headers, body))
+    def delete(uri: Uri, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Delete(uri, headers))
+    def trace(uri: Uri, headers: Map[String, String]): HttpRequestIO[HttpResponse] = Free.liftF(Trace(uri, headers))
   }
 
   class HttpRequestC[F[_]](implicit I: Inject[HttpRequestF, F]) {
-    def options(url: String, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Options(url, headers))
-    def get(url: String, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Get(url, headers))
-    def head(url: String, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Head(url, headers))
-    def post(url: String, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Post(url, headers, body))
-    def put(url: String, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Put(url, headers, body))
-    def delete(url: String, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Delete(url, headers))
-    def trace(url: String, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Trace(url, headers))
+    def options(uri: Uri, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Options(uri, headers))
+    def get(uri: Uri, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Get(uri, headers))
+    def head(uri: Uri, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Head(uri, headers))
+    def post(uri: Uri, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Post(uri, headers, body))
+    def put(uri: Uri, headers: Map[String, String], body: Option[String]): Free[F, HttpResponse] = Free.inject(Put(uri, headers, body))
+    def delete(uri: Uri, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Delete(uri, headers))
+    def trace(uri: Uri, headers: Map[String, String]): Free[F, HttpResponse] = Free.inject(Trace(uri, headers))
   }
 
   object HttpRequestC {

--- a/core/shared/src/main/scala/hammock/hi/Opts.scala
+++ b/core/shared/src/main/scala/hammock/hi/Opts.scala
@@ -7,33 +7,31 @@ import monocle.macros.GenLens
 case class Opts(
   auth: Option[Auth],
   headers: Map[String, String],
-  params: Map[String, String],
   cookies: Option[List[Cookie]])
 
 object Opts {
+
   object optics {
 
     val authOpt = GenLens[Opts](_.auth)
 
     val auth = Optional[Opts, Auth] {
-      case Opts(None, _, _, _) => None
-      case Opts(s@Some(x), _, _, _) => s
+      case Opts(None, _, _) => None
+      case Opts(s@Some(x), _, _) => s
     } (auth => (s => authOpt.set(Some(auth))(s)))
 
     val headers = GenLens[Opts](_.headers)
 
-    val params = GenLens[Opts](_.params)
-
     val cookiesOpt = GenLens[Opts](_.cookies)
     val cookies = Optional[Opts, List[Cookie]] {
-      case Opts(_, _, _, None) => None
-      case Opts(_, _, _, s@Some(_)) => s
+      case Opts(_, _, None) => None
+      case Opts(_, _, s@Some(_)) => s
     } (cookies => (s => cookiesOpt.set(Some(cookies))(s)))
 
   }
 
   implicit val defaultOptions = new Default[Opts] {
-    def default = Opts(None, Map(), Map(), None)
+    def default = Opts(None, Map(), None)
   }
 
   val default = Default[Opts].default

--- a/core/shared/src/main/scala/hammock/hi/dsl.scala
+++ b/core/shared/src/main/scala/hammock/hi/dsl.scala
@@ -13,10 +13,6 @@ object dsl {
   def headers(headers: Map[String, String]): Opts => Opts = Opts.optics.headers.modify(headers ++ _)
   def header(header: (String, String)): Opts => Opts = Opts.optics.headers.modify(_ + header)
 
-  def params_!(params: Map[String, String]): Opts => Opts = Opts.optics.params.set(params)
-  def params(params: Map[String, String]): Opts => Opts = Opts.optics.params.modify(params ++ _)
-  def param(param: (String, String)): Opts => Opts = Opts.optics.params.modify(_ + param)
-
   implicit class opts2OptsSyntax(a: Opts => Opts) {
     def &>(b: Opts => Opts): Opts => Opts = a compose b
   }

--- a/core/shared/src/test/scala/hammock/HammockSpec.scala
+++ b/core/shared/src/test/scala/hammock/HammockSpec.scala
@@ -3,6 +3,7 @@ package hammock
 import free.algebra._
 import org.scalatest._
 import cats._
+import cats.syntax.show._
 import hi.{Opts, Cookie}
 
 class HammockSpec extends WordSpec with Matchers {
@@ -15,36 +16,39 @@ class HammockSpec extends WordSpec with Matchers {
      Method.DELETE,
      Method.TRACE)
 
+
+  implicit val stringCodec = new Codec[String] {
+    def encode(s: String) = s
+    def decode(s: String) = Right(s)
+  }
+
+  /**
+    * This is really dirty... but I cannot come up with a better solution right now...
+    */
+  def test(assertions: HttpRequestF[_] => Any) = new (HttpRequestF ~> Id) {
+    def apply[A](h: HttpRequestF[A]): A = {
+      assertions(h)
+
+      null.asInstanceOf[A]
+    }
+  }
+
+  val uri = Uri.fromString("http://pepegar.com").right.get
+
   "Hammock.request" should {
-
-    implicit val stringCodec = new Codec[String] {
-      def encode(s: String) = s
-      def decode(s: String) = Right(s)
-    }
-
-    /**
-      * This is really dirty... but I cannot come up with a better solution right now...
-      */
-    def test(assertions: HttpRequestF[_] => Any) = new (HttpRequestF ~> Id) {
-      def apply[A](h: HttpRequestF[A]): A = {
-        assertions(h)
-
-        null.asInstanceOf[A]
-      }
-    }
 
     methods.map { method =>
       s"create a valid $method request without a body" in {
-        Hammock.request(method, "http://pepegar.com", Map()) foldMap test { r =>
-          r.url shouldEqual "http://pepegar.com"
+        Hammock.request(method, uri, Map()) foldMap test { r =>
+          r.uri shouldEqual Uri.fromString("http://pepegar.com").right.get
           r.headers shouldEqual Map()
         }
       }
 
       s"create a valid $method request with a body" in {
         val body = None
-        Hammock.request(method, "http://pepegar.com", Map(), body) foldMap test { r =>
-          r.url shouldEqual "http://pepegar.com"
+        Hammock.request(method, uri, Map(), body) foldMap test { r =>
+          r.uri shouldEqual Uri.fromString("http://pepegar.com").right.get
           r.headers shouldEqual Map()
           r.body shouldEqual None
         }
@@ -52,13 +56,16 @@ class HammockSpec extends WordSpec with Matchers {
     }
 
     "work with the options variant" in {
-      val opts = Opts(None, Map("header" -> "3"), Map("urlParam" -> "44"), Some(List(Cookie("thisisacookie", "thisisthevalue"))))
+      val opts = Opts(None, Map("header" -> "3"), Some(List(Cookie("thisisacookie", "thisisthevalue"))))
 
-      Hammock.getWithOpts("http://pepegar.com", opts) foldMap test { r =>
-        r.url shouldEqual "http://pepegar.com?urlParam=44"
-        r.headers shouldEqual Map("header" -> "3", "Set-Cookie" -> "thisisacookie=thisisthevalue")
+      Uri.fromString("http://pepegar.com") match {
+        case Right(uri) =>
+          Hammock.getWithOpts(uri, opts) foldMap test { r =>
+            r.uri shouldEqual Uri.fromString("http://pepegar.com").right.get
+            r.headers shouldEqual Map("header" -> "3", "Set-Cookie" -> "thisisacookie=thisisthevalue")
+          }
+        case Left(err) => fail(s"failed with $err")
       }
-
     }
   }
 }

--- a/core/shared/src/test/scala/hammock/UriSpec.scala
+++ b/core/shared/src/test/scala/hammock/UriSpec.scala
@@ -1,0 +1,52 @@
+package hammock
+
+import org.scalatest._
+
+import atto._
+import Atto._
+import atto.compat.cats._
+import cats._
+import cats.implicits._
+import cats.syntax.either._
+
+class UriSpec extends WordSpec with Matchers {
+
+  "Uri.fromString" should {
+    "parse uris with only a path" in {
+      Uri.fromString("/test") shouldEqual Right(Uri(path = "/test"))
+    }
+
+    "parse uris with a scheme" in {
+      Uri.fromString("http://pepegar.com") shouldEqual Right(Uri(scheme = Option("http"), path = "pepegar.com"))
+    }
+
+    "parse uris with an authority" in {
+      Uri.fromString("http://user:pass@pepegar.com") shouldEqual Right(Uri(
+        scheme = Option("http"),
+        authority = Option("user:pass"),
+        path = "pepegar.com"
+      ))
+    }
+
+    "parse uris with query params" in {
+      Uri.fromString("http://user:pass@pepegar.com?test=3&anotherTest=asdlfkj8") shouldEqual Right(Uri(
+        scheme = Option("http"),
+        authority = Option("user:pass"),
+        path = "pepegar.com",
+        query = Map("test" -> "3", "anotherTest" -> "asdlfkj8")
+      ))
+    }
+
+    "parse uris with fragment" in {
+      Uri.fromString("http://user:pass@pepegar.com?test=3&anotherTest=asdlfkj8#122") shouldEqual Right(Uri(
+        scheme = Option("http"),
+        authority = Option("user:pass"),
+        path = "pepegar.com",
+        query = Map("test" -> "3", "anotherTest" -> "asdlfkj8"),
+        fragment = Some("122")
+      ))
+    }
+
+
+  }
+}

--- a/core/shared/src/test/scala/hammock/UriSpec.scala
+++ b/core/shared/src/test/scala/hammock/UriSpec.scala
@@ -43,10 +43,45 @@ class UriSpec extends WordSpec with Matchers {
         authority = Option("user:pass"),
         path = "pepegar.com",
         query = Map("test" -> "3", "anotherTest" -> "asdlfkj8"),
+
         fragment = Some("122")
       ))
     }
+  }
 
+  "Uri.toString" should {
+    "create valid URI when only the path is present" in {
+      Uri(path = "/asdf").show shouldEqual "/asdf"
+    }
 
+    "create valid URI when there is a scheme" in {
+      Uri(
+        scheme = "http".some,
+        path = "potato.com").show shouldEqual "http://potato.com"
+    }
+
+    "create valid URI when there is an authority" in {
+      Uri(
+        authority = "user:pass".some,
+        scheme = "ftp".some,
+        path = "patata.com").show shouldEqual "ftp://user:pass@patata.com"
+    }
+
+    "create valid URI when therer are query params" in {
+      Uri(
+        authority = "user:pass".some,
+        scheme = "ftp".some,
+        path = "patata.com",
+        query = Map("page" -> "33", "sauce" -> "bbq")).show shouldEqual "ftp://user:pass@patata.com?page=33&sauce=bbq"
+    }
+
+    "create valid URI when there is a fragment" in {
+      Uri(
+        authority = "user:pass".some,
+        scheme = "ftp".some,
+        path = "patata.com",
+        query = Map("page" -> "33", "sauce" -> "bbq"),
+        fragment = "index".some).show shouldEqual "ftp://user:pass@patata.com?page=33&sauce=bbq#index"
+    }
   }
 }

--- a/core/shared/src/test/scala/hammock/hi/DslSpec.scala
+++ b/core/shared/src/test/scala/hammock/hi/DslSpec.scala
@@ -13,10 +13,9 @@ class DslSpec extends WordSpec with Matchers {
     "allow concatenation of operations" in {
       val req = (
         auth(Auth.BasicAuth("pepegar", "h4rdp4ssw0rd")) &>
-        param("page" -> "43") &>
         header("X-Forwarded-Proto" -> "https"))(Opts.default)
 
-      req shouldEqual Opts(Some(Auth.BasicAuth("pepegar", "h4rdp4ssw0rd")),Map("X-Forwarded-Proto" -> "https"), Map("page" -> "43"),None)
+      req shouldEqual Opts(Some(Auth.BasicAuth("pepegar", "h4rdp4ssw0rd")),Map("X-Forwarded-Proto" -> "https"),None)
     }
   }
 

--- a/docs/src/main/tut/docs.md
+++ b/docs/src/main/tut/docs.md
@@ -120,6 +120,7 @@ Hammock, you can import `hammock.free._` and enjoy:
 
 ```tut:silent
 object App {
+  import hammock.Uri._
   import IO._
   import Log._
   import cats._
@@ -137,7 +138,7 @@ object App {
     _ <- IO.write("What's the ID?")
     id = "4" // for the sake of docs, lets hardcode this... It should be `id <- IO.read`
     _ <- Log.info(s"id was $id")
-    response <- Hammock.get(s"https://jsonplaceholder.typicode.com/users?id=$id", Map())
+    response <- Hammock.get(uri"https://jsonplaceholder.typicode.com/users?id=${id.toString}", Map())
   } yield response
 
   def interp1[F[_]](implicit ME: MonadError[F, Throwable]): Eff1 ~> F = Log.interp(ME) or IO.interp(ME)
@@ -168,6 +169,7 @@ your requests.
 
 ```tut:book
 import hammock._
+import hammock.Uri._
 import hammock.jvm.free.Interpreter
 import hammock.hi._
 import hammock.hi.dsl._
@@ -177,9 +179,9 @@ import cats.implicits._
 
 implicit val interp = Interpreter()
 
-val opts = (header("user" -> "pepegar") &> param("pageId" -> "3"))(Opts.default)
+val opts = (header("user" -> "pepegar") &> cookie(Cookie("track", "a lot")))(Opts.default)
 
-val response = Hammock.getWithOpts("http://httpbin.org/get", opts).exec[Try]
+val response = Hammock.getWithOpts(uri"http://httpbin.org/get", opts).exec[Try]
 ```
 
 ## Opts
@@ -210,8 +212,7 @@ Here's an example of how can you use the high level DSL:
 val req = {
   auth(Auth.BasicAuth("pepegar", "p4ssw0rd")) &>
     cookie(Cookie("track", "A lot")) &>
-    header("user" -> "") &>
-    param("page" -> "33")
+    header("user" -> "potatoman")
 }
 ```
 

--- a/docs/src/main/tut/docs.md
+++ b/docs/src/main/tut/docs.md
@@ -194,7 +194,6 @@ This `Opts` type is later compiled by the `withOpts` methods to the
 case class Opts(
   auth: Option[Auth],
   headers: Map[String, String],
-  params: Map[String, String],
   cookies: Option[List[Cookie]])
 ```
 
@@ -297,21 +296,6 @@ Appends current `header` (a `(String, String)` value) to the headers
 map.
 
 
-#### Params (query params)
-
-Hammock provides helper functions for handling query params in URLs:
-
-`params_!(params: Map[String, String]): Opts => Opts`
-
-Sets the query string part of the url to the given params.
-
-`params(params: Map[String, String]): Opts => Opts`
-
-Appends params to the query string.
-
-`param(param: (String, String)): Opts => Opts`
-
-Adds the given param to the query string.
 
 
 # Codecs

--- a/docs/src/main/tut/docs.md
+++ b/docs/src/main/tut/docs.md
@@ -204,6 +204,16 @@ combinator of `Function1`.  Also, Hammock provides a helper combinator
 
 ### Combinators that operate on `Opts`
 
+| signature                                               | description                                                                  |
+|---------------------------------------------------------+------------------------------------------------------------------------------|
+| `auth(a: Auth): Opts => Opts`                           | Sets the `auth` field in opts                                                |
+| `cookies_!(cookies: List[Cookie]): Opts => Opts`        | Substitutes the current value of `cookies` in the given `Opts` by its param. |
+| `cookies(cookies: List[Cookie]): Opts => Opts`          | Appends the given cookies to the current value of `cookies`.                 |
+| `cookie(cookie: Cookie): Opts => Opts`                  | Adds the given `Cookie` to the `Opts` value.                                 |
+| `headers_!(headers: Map[String, String]): Opts => Opts` | Sets the `headers`.                                                          |
+| `headers(headers: Map[String, String]): Opts => Opts`   | Appends the given `headers` to the former ones.                              |
+| `header(header: (String, String)): Opts => Opts`        | Appends current `header` (a `(String, String)` value) to the headers map.    |
+
 Here's an example of how can you use the high level DSL:
 
 
@@ -225,13 +235,6 @@ Hammock:
   token. This is treated by many services like a user/password pair
 * **OAuth2 token** (`Auth.OAuth2Token(token: String)`): This is a _not really standard_ bearer token.
   Will be treated by services as user/password.
-
-You can manipulate Authentication headers with:
-
-`auth(a: Auth): Opts => Opts`
-
-Sets the `auth` field of the given opts to `a`.
-
 
 #### Cookies
 
@@ -264,39 +267,11 @@ val cookie = Cookie("_ga", "werwer")
 Cookie.maxAge.set(Some(234))(cookie)
 ```
 
-The combinators that hammock provides for handling cookies are:
-
-`cookies_!(cookies: List[Cookie]): Opts => Opts`
-
-Substitutes the current value of `cookies` in the given `Opts` by its
-param.
-
-`cookies(cookies: List[Cookie]): Opts => Opts`
-
-Appends the given cookies to the current value of `cookies`.
-
-`cookie(cookie: Cookie): Opts => Opts`
-
-Adds the given `Cookie` to the `Opts` value.
-
-
 #### Headers
 
-`headers_!(headers: Map[String, String]): Opts => Opts`
-
-Sets the `headers`.
-
-`headers(headers: Map[String, String]): Opts => Opts`
-
-Appends the given `headers` to the former ones.
-
-`header(header: (String, String)): Opts => Opts`
-
-Appends current `header` (a `(String, String)` value) to the headers
-map.
-
-
-
+Headers in the `Opts` type are represented by a `Map[String, String]`.
+In this field, you normally want to put all the headers that are not
+strictly cookies or authentication header.
 
 # Codecs
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -46,6 +46,7 @@ import scala.util.{ Failure, Success, Try }
 import io.circe._
 import io.circe.generic.auto._
 import hammock._
+import hammock.Uri._
 import hammock.hi._
 import hammock.jvm.free.Interpreter
 import hammock.circe.implicits._
@@ -55,7 +56,7 @@ object HttpClient {
   implicit val interp = Interpreter()
 
   val response = Hammock
-    .getWithOpts("https://api.fidesmo.com/apps", Opts.default)
+    .getWithOpts(uri"https://api.fidesmo.com/apps", Opts.default)
     .exec[Try]
     .as[List[String]]
 }

--- a/example-js/src/main/scala/examplejs/Main.scala
+++ b/example-js/src/main/scala/examplejs/Main.scala
@@ -19,14 +19,20 @@ import io.circe.generic.auto._
 object Main extends JSApp {
   def main(): Unit = {
 
+    import Codec._
     implicit val interpTrans = Interpreter
+
     case class Resp(json: String)
     case class Data(name: String, number: Int)
 
-    val request = Hammock
-      .request(Method.POST, "http://httpbin.org/post", Map(), Some(Codec[Data].encode(Data("name", 4))))
-      .exec[Try]
-      .as[Resp]
+    val uriFromString: Try[Uri] = Uri.fromString("http://httpbin.org/post").leftMap(new Exception(_)).toTry
+
+    val request: Try[Resp] = uriFromString >>= { uri =>
+      Hammock
+        .request(Method.POST, uri, Map(), Some(Data("name", 4).encode))
+        .exec[Try]
+        .as[Resp]
+    }
 
     request match {
       case Success(resp) =>


### PR DESCRIPTION
Introduces a `Uri` class that will be used on the high level API.

## ~~Waiting for [atto](https://github.com/tpolecat/atto) to be cross-compiled to ScalaJS, since we're using at our very core right now.~~ Done now :)

## TODO:
- [x] tests for toString (will be used to translate to the raw string that the low level uses.
- [x] integrate on `hi`

closes https://github.com/pepegar/hammock/issues/26