### PR TITLE
modify DSL cookie combinators to make them work on Default

### DIFF
--- a/core/shared/src/main/scala/hammock/hi/Opts.scala
+++ b/core/shared/src/main/scala/hammock/hi/Opts.scala
@@ -23,10 +23,6 @@ object Opts {
     val headers = GenLens[Opts](_.headers)
 
     val cookiesOpt = GenLens[Opts](_.cookies)
-    val cookies = Optional[Opts, List[Cookie]] {
-      case Opts(_, _, None) => None
-      case Opts(_, _, s@Some(_)) => s
-    } (cookies => (s => cookiesOpt.set(Some(cookies))(s)))
 
   }
 

--- a/core/shared/src/main/scala/hammock/hi/dsl.scala
+++ b/core/shared/src/main/scala/hammock/hi/dsl.scala
@@ -5,9 +5,15 @@ object dsl {
 
   def auth(a: Auth): Opts => Opts = Opts.optics.auth.set(a)
 
-  def cookies_!(cookies: List[Cookie]): Opts => Opts = Opts.optics.cookies.set(cookies)
-  def cookies(cookies: List[Cookie]): Opts => Opts = Opts.optics.cookies.modify(cookies ++ _)
-  def cookie(cookie: Cookie): Opts => Opts = Opts.optics.cookies.modify(cookie :: _)
+  def cookies_!(cookies: List[Cookie]): Opts => Opts = Opts.optics.cookiesOpt.set(Some(cookies))
+  def cookies(cookies: List[Cookie]): Opts => Opts = Opts.optics.cookiesOpt.modify {
+    case None => Some(cookies)
+    case c => c.map(cookies ++ _)
+  }
+  def cookie(cookie: Cookie): Opts => Opts = Opts.optics.cookiesOpt.modify {
+    case None => Some(List(cookie))
+    case c => c.map(cookie :: _)
+  }
 
   def headers_!(headers: Map[String, String]): Opts => Opts = Opts.optics.headers.set(headers)
   def headers(headers: Map[String, String]): Opts => Opts = Opts.optics.headers.modify(headers ++ _)

--- a/core/shared/src/test/scala/hammock/hi/DslSpec.scala
+++ b/core/shared/src/test/scala/hammock/hi/DslSpec.scala
@@ -3,19 +3,32 @@ package hi
 
 import org.scalatest._
 
-import monocle.syntax.all._
-
 class DslSpec extends WordSpec with Matchers {
 
   import dsl._
+
+  "`cookies`" should {
+    "work when there were no cookies before" in {
+      val opts = cookies(List(Cookie("a", "b"), Cookie("c", "d")))(Opts.default)
+
+      opts shouldEqual Opts(None, Map(), Some(List(Cookie("a", "b"), Cookie("c", "d"))))
+    }
+
+    "preppend cookies when there were cookies before" in {
+      val opts = cookies(List(Cookie("c", "d"), Cookie("e", "f")))(Opts(None, Map(), Some(List(Cookie("a", "b")))))
+
+      opts shouldEqual Opts(None, Map(), Some(List(Cookie("c", "d"), Cookie("e", "f"), Cookie("a", "b"))))
+    }
+  }
 
   "hi.dsl" should {
     "allow concatenation of operations" in {
       val req = (
         auth(Auth.BasicAuth("pepegar", "h4rdp4ssw0rd")) &>
-        header("X-Forwarded-Proto" -> "https"))(Opts.default)
+        header("X-Forwarded-Proto" -> "https") &>
+        cookie(Cookie("track", "A lot")))(Opts.default)
 
-      req shouldEqual Opts(Some(Auth.BasicAuth("pepegar", "h4rdp4ssw0rd")),Map("X-Forwarded-Proto" -> "https"),None)
+      req shouldEqual Opts(Some(Auth.BasicAuth("pepegar", "h4rdp4ssw0rd")),Map("X-Forwarded-Proto" -> "https"), Some(List(Cookie("track", "A lot"))))
     }
   }
 


### PR DESCRIPTION
The bug was that cookies combinators weren't working when there were no cookies before in the `Opts`