### PR TITLE
Make sure all entities are consumed in Apache HTTP interpreter

### DIFF
--- a/core/jvm/src/main/scala/hammock/jvm/free/Interpreter.scala
+++ b/core/jvm/src/main/scala/hammock/jvm/free/Interpreter.scala
@@ -8,14 +8,15 @@ import cats._
 import cats.data._
 import cats.syntax.show._
 
-import java.io.{ BufferedReader, InputStream, InputStreamReader }
-import org.apache.http.Header
+import java.io.{BufferedReader, InputStream, InputStreamReader}
 
+import org.apache.http.Header
 import org.apache.http.client.HttpClient
 import org.apache.http.client.methods._
 import org.apache.http.entity.StringEntity
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.message.BasicHeader
+import org.apache.http.util.EntityUtils
 
 class Interpreter(client: HttpClient) extends InterpTrans {
 
@@ -43,9 +44,11 @@ class Interpreter(client: HttpClient) extends InterpTrans {
       }
 
       val resp = client.execute(req)
-      val body = responseContentToString(resp.getEntity().getContent())
+      val entity = resp.getEntity
+      val body = responseContentToString(entity.getContent())
       val status = Status.get(resp.getStatusLine.getStatusCode)
       val responseHeaders = resp.getAllHeaders().map(h => h.getName -> h.getValue).toMap
+      EntityUtils.consume(entity)
 
       HttpResponse(status, responseHeaders, body)
     }


### PR DESCRIPTION
We need to consume the whole entity in order to release a connection in all cases (so that it can be reused).

More info: https://stackoverflow.com/questions/30889984/whats-the-difference-between-closeablehttpresponse-close-and-httppost-release

Fixes #47.