### PR TITLE
Add declarative as syntax

### DIFF
--- a/core/shared/src/main/scala/hammock/HttpResponseToDecode.scala
+++ b/core/shared/src/main/scala/hammock/HttpResponseToDecode.scala
@@ -1,0 +1,12 @@
+package hammock
+
+import cats.Eq
+
+case class HttpResponseToDecode[T](response: HttpResponse)
+
+object HttpResponseToDecode {
+  implicit def eqHttpResponse[T] = new Eq[HttpResponseToDecode[T]] {
+    def eqv(x: HttpResponseToDecode[T], y: HttpResponseToDecode[T]): Boolean =
+      Eq[HttpResponse].eqv(x.response, y.response)
+  }
+}

--- a/core/shared/src/main/scala/hammock/package.scala
+++ b/core/shared/src/main/scala/hammock/package.scala
@@ -21,4 +21,13 @@ package object hammock {
       }
     }
   }
+
+  implicit class HttpResponseToDecodeIOSyntax[T : Codec](fa: Free[HttpRequestF, HttpResponseToDecode[T]]) {
+    def exec[F[_]](implicit interp: InterpTrans, ME: MonadError[F, Throwable]): F[T] =
+      fa.foldMap(interp.trans(ME)).map(_.response).as[T]
+  }
+
+  implicit class HttpResponseAs[A](fa: Free[HttpRequestF, HttpResponse]) {
+    def as[T : Codec]: Free[HttpRequestF, HttpResponseToDecode[T]] = fa.map(HttpResponseToDecode.apply[T])
+  }
 }

--- a/example/src/main/scala/example/DeclarativeAsExample.scala
+++ b/example/src/main/scala/example/DeclarativeAsExample.scala
@@ -1,0 +1,19 @@
+package example
+
+import cats.instances.try_._
+import hammock._
+import hammock.circe.implicits._
+import hammock.jvm.free.Interpreter
+
+import scala.util.Try
+
+object DeclarativeAsExample extends App {
+  implicit val interpreter = Interpreter()
+
+  val response = Hammock
+    .request(Method.GET, Uri.unsafeParse("https://api.fidesmo.com/apps"), Map())
+    .as[List[String]]
+    .exec[Try]
+
+  println(response)
+}


### PR DESCRIPTION
I thought about moving `as` syntax before the interpretation phase and come up with something like that. There is an alternative approach that is based on creating a new operation in algebra (decodeAs) and decoding as interpretation step.

Any thoughts @pepegar?