### PR TITLE
Simplify api and packages

### DIFF
--- a/core/js/src/main/scala/hammock/hi/platformspecific.scala
+++ b/core/js/src/main/scala/hammock/hi/platformspecific.scala
@@ -1,9 +1,10 @@
 package hammock
+package hi
 
 import java.util.{Date => JavaDate}
 import scalajs.js.{Date => JsDate}
 
-package object hi {
+object platformspecific {
   def convert(d: JavaDate): JsDate = new JsDate(d.getTime().toDouble)
 
   implicit object JSDateFormatter extends DateFormatter {

--- a/core/jvm/src/main/scala/hammock/hi/platformspecific.scala
+++ b/core/jvm/src/main/scala/hammock/hi/platformspecific.scala
@@ -1,9 +1,10 @@
 package hammock
+package hi
 
 import java.text.SimpleDateFormat
 import java.util.Date
 
-package object hi {
+object platformspecific {
   implicit object JVMDateFormatter extends DateFormatter {
     private val fmt                = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z")
     def format(date: Date): String = fmt.format(date)

--- a/core/shared/src/main/scala/hammock/Hammock.scala
+++ b/core/shared/src/main/scala/hammock/Hammock.scala
@@ -45,16 +45,16 @@ object Hammock {
    * Usage:
    *
    * {{{
-   * scala> import hammock._, hammock.jvm.Interpreter, hammock.hi._, hammock.hi.dsl._, cats._, cats.implicits._, scala.util.Try
+   * scala> import hammock._, hammock.jvm.Interpreter, hammock.hi._, hammock.hi._, cats._, cats.implicits._, scala.util.Try
    * import hammock._
    * import hammock.jvm.Interpreter
    * import hammock.hi._
-   * import hammock.hi.dsl._
+   * import hammock.hi._
    * import cats._
    * import cats.implicits._
    * import scala.util.Try
    *
-   * scala> val opts = (header("X-Test" -> "works!") &> auth(Auth.BasicAuth("user", "pass")) &> cookie(Cookie("key", "value")))(Opts.empty)
+   * scala> val opts = (header("X-Test" -> "works!") >>> auth(Auth.BasicAuth("user", "pass")) >>> cookie(Cookie("key", "value")))(Opts.empty)
    * opts: hammock.hi.Opts = Opts(Some(BasicAuth(user,pass)),Map(X-Test -> works!),Some(List(Cookie(key,value,None,None,None,None,None,None,None,None))))
    *
    * scala> val response = Hammock.withOpts(Method.GET, Uri.unsafeParse("http://httpbin.org/get"), opts)
@@ -77,16 +77,16 @@ object Hammock {
   /** Creates an OPTIONS request to the given [[Uri uri]] and [[hi.Opts opts]].
    *
    * {{{
-   * scala> import hammock._, hammock.jvm.Interpreter, hammock.hi._, hammock.hi.dsl._, cats._, cats.implicits._, scala.util.Try
+   * scala> import hammock._, hammock.jvm.Interpreter, hammock.hi._, hammock.hi._, cats._, cats.implicits._, scala.util.Try
    * import hammock._
    * import hammock.jvm.Interpreter
    * import hammock.hi._
-   * import hammock.hi.dsl._
+   * import hammock.hi._
    * import cats._
    * import cats.implicits._
    * import scala.util.Try
    *
-   * scala> val opts = (header("X-Test" -> "works!") &> auth(Auth.BasicAuth("user", "pass")) &> cookie(Cookie("key", "value")))(Opts.empty)
+   * scala> val opts = (header("X-Test" -> "works!") >>> auth(Auth.BasicAuth("user", "pass")) >>> cookie(Cookie("key", "value")))(Opts.empty)
    * opts: hammock.hi.Opts = Opts(Some(BasicAuth(user,pass)),Map(X-Test -> works!),Some(List(Cookie(key,value,None,None,None,None,None,None,None,None))))
    *
    * scala> Hammock.optionsWithOpts(Uri.unsafeParse("http://httpbin.org/get"), opts)
@@ -99,16 +99,16 @@ object Hammock {
   /** Creates a GET request to the given [[Uri uri]] and [[hi.Opts opts]].
    *
    * {{{
-   * scala> import hammock._, hammock.jvm.Interpreter, hammock.hi._, hammock.hi.dsl._, cats._, cats.implicits._, scala.util.Try
+   * scala> import hammock._, hammock.jvm.Interpreter, hammock.hi._, hammock.hi._, cats._, cats.implicits._, scala.util.Try
    * import hammock._
    * import hammock.jvm.Interpreter
    * import hammock.hi._
-   * import hammock.hi.dsl._
+   * import hammock.hi._
    * import cats._
    * import cats.implicits._
    * import scala.util.Try
    *
-   * scala> val opts = (header("X-Test" -> "works!") &> auth(Auth.BasicAuth("user", "pass")) &> cookie(Cookie("key", "value")))(Opts.empty)
+   * scala> val opts = (header("X-Test" -> "works!") >>> auth(Auth.BasicAuth("user", "pass")) >>> cookie(Cookie("key", "value")))(Opts.empty)
    * opts: hammock.hi.Opts = Opts(Some(BasicAuth(user,pass)),Map(X-Test -> works!),Some(List(Cookie(key,value,None,None,None,None,None,None,None,None))))
    *
    * scala> Hammock.getWithOpts(Uri.unsafeParse("http://httpbin.org/get"), opts)
@@ -124,12 +124,12 @@ object Hammock {
    * import hammock._
    * import hammock.jvm.Interpreter
    * import hammock.hi._
-   * import hammock.hi.dsl._
+   * import hammock.hi._
    * import cats._
    * import cats.implicits._
    * import scala.util.Try
    *
-   * val opts = (header("X-Test" -> "works!") &> auth(Auth.BasicAuth("user", "pass")) &> cookie(Cookie("key", "value")))(Opts.empty)
+   * val opts = (header("X-Test" -> "works!") >>> auth(Auth.BasicAuth("user", "pass")) >>> cookie(Cookie("key", "value")))(Opts.empty)
    *
    * Hammock.headWithOpts(Uri.unsafeParse("http://httpbin.org/get"), opts)
    * }}}
@@ -145,12 +145,12 @@ object Hammock {
    * import hammock._
    * import hammock.jvm.Interpreter
    * import hammock.hi._
-   * import hammock.hi.dsl._
+   * import hammock.hi._
    * import cats._
    * import cats.implicits._
    * import scala.util.Try
    *
-   * val opts = (header("X-Test" -> "works!") &> auth(Auth.BasicAuth("user", "pass")) &> cookie(Cookie("key", "value")))(Opts.empty)
+   * val opts = (header("X-Test" -> "works!") >>> auth(Auth.BasicAuth("user", "pass")) >>> cookie(Cookie("key", "value")))(Opts.empty)
    *
    * implicit val stringCodec = new Codec[String] {
    *    def encode(s: String) = s
@@ -171,12 +171,12 @@ object Hammock {
    * import hammock._
    * import hammock.jvm.Interpreter
    * import hammock.hi._
-   * import hammock.hi.dsl._
+   * import hammock.hi._
    * import cats._
    * import cats.implicits._
    * import scala.util.Try
    *
-   * val opts = (header("X-Test" -> "works!") &> auth(Auth.BasicAuth("user", "pass")) &> cookie(Cookie("key", "value")))(Opts.empty)
+   * val opts = (header("X-Test" -> "works!") >>> auth(Auth.BasicAuth("user", "pass")) >>> cookie(Cookie("key", "value")))(Opts.empty)
    *
    * implicit val stringCodec = new Codec[String] {
    *    def encode(s: String) = s
@@ -193,7 +193,7 @@ object Hammock {
   /** Creates a DELETE request to the given [[Uri uri]] and [[hi.Opts opts]].
    *
    * {{{
-   * val opts = (header("X-Test" -> "works!") &> auth(Auth.BasicAuth("user", "pass")) &> cookie(Cookie("key", "value")))(Opts.empty)
+   * val opts = (header("X-Test" -> "works!") >>> auth(Auth.BasicAuth("user", "pass")) >>> cookie(Cookie("key", "value")))(Opts.empty)
    *
    * Hammock.deleteWithOpts(Uri.unsafeParse("http://httpbin.org/get"), opts)
    * }}}
@@ -204,7 +204,7 @@ object Hammock {
   /** Creates a TRACE request to the given [[Uri uri]] and [[hi.Opts opts]].
    *
    * {{{
-   * val opts = (header("X-Test" -> "works!") &> auth(Auth.BasicAuth("user", "pass")) &> cookie(Cookie("key", "value")))(Opts.empty)
+   * val opts = (header("X-Test" -> "works!") >>> auth(Auth.BasicAuth("user", "pass")) >>> cookie(Cookie("key", "value")))(Opts.empty)
    *
    * Hammock.traceWithOpts(Uri.unsafeParse("http://httpbin.org/get"), opts)
    * }}}

--- a/core/shared/src/main/scala/hammock/hi/Cookie.scala
+++ b/core/shared/src/main/scala/hammock/hi/Cookie.scala
@@ -6,6 +6,7 @@ import java.util.Date
 import cats._
 import cats.implicits._
 import hammock.hi.Cookie.SameSite
+import hammock.hi.platformspecific._
 import monocle.Optional
 import monocle.macros.Lenses
 

--- a/core/shared/src/main/scala/hammock/hi/package.scala
+++ b/core/shared/src/main/scala/hammock/hi/package.scala
@@ -1,8 +1,6 @@
 package hammock
-package hi
 
-object dsl {
-
+package object hi {
   def auth(a: Auth): Opts => Opts = Opts.auth.set(Some(a))
 
   def cookies_!(cookies: List[Cookie]): Opts => Opts = Opts.cookies.set(Some(cookies))
@@ -20,6 +18,7 @@ object dsl {
   def header(header: (String, String)): Opts => Opts        = Opts.headers.modify(_ + header)
 
   implicit class opts2OptsSyntax(a: Opts => Opts) {
+    @deprecated("use cats' <<< or >>> instead")
     def &>(b: Opts => Opts): Opts => Opts = a compose b
   }
 }

--- a/core/shared/src/test/scala/hammock/hi/DslSpec.scala
+++ b/core/shared/src/test/scala/hammock/hi/DslSpec.scala
@@ -1,6 +1,7 @@
 package hammock
 package hi
 
+import cats.implicits._
 import org.scalatest._
 
 class DslSpec extends WordSpec with Matchers {
@@ -23,8 +24,8 @@ class DslSpec extends WordSpec with Matchers {
 
   "hi.dsl" should {
     "allow concatenation of operations" in {
-      val req = (auth(Auth.BasicAuth("pepegar", "h4rdp4ssw0rd")) &>
-        header("X-Forwarded-Proto" -> "https") &>
+      val req = (auth(Auth.BasicAuth("pepegar", "h4rdp4ssw0rd")) >>>
+        header("X-Forwarded-Proto" -> "https") >>>
         cookie(Cookie("track", "A lot")))(Opts.empty)
 
       req shouldEqual Opts(

--- a/core/shared/src/test/scala/hammock/hi/DslSpec.scala
+++ b/core/shared/src/test/scala/hammock/hi/DslSpec.scala
@@ -6,8 +6,6 @@ import org.scalatest._
 
 class DslSpec extends WordSpec with Matchers {
 
-  import dsl._
-
   "`cookies`" should {
     "work when there were no cookies before" in {
       val opts = cookies(List(Cookie("a", "b"), Cookie("c", "d")))(Opts.empty)
@@ -22,7 +20,7 @@ class DslSpec extends WordSpec with Matchers {
     }
   }
 
-  "hi.dsl" should {
+  "high level dsl" should {
     "allow concatenation of operations" in {
       val req = (auth(Auth.BasicAuth("pepegar", "h4rdp4ssw0rd")) >>>
         header("X-Forwarded-Proto" -> "https") >>>

--- a/docs/src/main/tut/interpreters.md
+++ b/docs/src/main/tut/interpreters.md
@@ -41,7 +41,6 @@ For demonstrating all the interpreters we'll use the same HTTP request:
 import cats.free.Free
 import hammock._
 import hammock.hi._
-import hammock.hi.dsl._
 
 val httpReq = Hammock.getWithOpts(
   Uri.unsafeParse("http://httpbin.org/get"),

--- a/hammock-akka-http/src/main/scala/hammock/akka/AkkaInterpreter.scala
+++ b/hammock-akka-http/src/main/scala/hammock/akka/AkkaInterpreter.scala
@@ -21,9 +21,8 @@ import cats.implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AkkaInterpreter[F[_]: Async](client: HttpExt)(
-    implicit materializer: ActorMaterializer,
-    executionContext: ExecutionContext)
+class AkkaInterpreter[F[_]: Async](
+    client: HttpExt)(implicit materializer: ActorMaterializer, executionContext: ExecutionContext)
     extends InterpTrans[F] {
 
   def trans(implicit S: Sync[F]): HttpF ~> F = transK andThen λ[Kleisli[F, HttpExt, ?] ~> F](_.run(client))

--- a/hammock-akka-http/src/main/scala/hammock/akka/AkkaInterpreter.scala
+++ b/hammock-akka-http/src/main/scala/hammock/akka/AkkaInterpreter.scala
@@ -21,8 +21,9 @@ import cats.implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AkkaInterpreter[F[_]: Async](
-    client: HttpExt)(implicit materializer: ActorMaterializer, executionContext: ExecutionContext)
+class AkkaInterpreter[F[_]: Async](client: HttpExt)(
+    implicit materializer: ActorMaterializer,
+    executionContext: ExecutionContext)
     extends InterpTrans[F] {
 
   def trans(implicit S: Sync[F]): HttpF ~> F = transK andThen λ[Kleisli[F, HttpExt, ?] ~> F](_.run(client))


### PR DESCRIPTION
This PR comes as an expansion of previous one #78. This pr:

- moves contents of `hammock.hi.dsl` to `hammock.hi`. When importing `hi`, you probably want to use the DSL...
- deprecates `&>` combinator, and encourages using cats' `>>>` or `<<<`
- moves `hammock.hi` in `JS` and `JVM` folders to `hammock.hi.platformspecific` , as that's what it is.