### PR TITLE
fix js client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -143,7 +143,7 @@ val commonDependencies = Seq(
     "org.typelevel"              %%% "cats-laws"      % Versions("cats"),
     "org.typelevel"              %%% "alleycats-core" % Versions("cats"),
     "com.propensive"             %%% "contextual"     % Versions("contextual"),
-    "org.typelevel"              %% "cats-effect"     % Versions("cats-effect"),
+    "org.typelevel"              %%% "cats-effect"    % Versions("cats-effect"),
     "com.github.mpilquist"       %%% "simulacrum"     % Versions("simulacrum"),
     "com.github.julien-truffaut" %%% "monocle-core"   % Versions("monocle"),
     "com.github.julien-truffaut" %%% "monocle-macro"  % Versions("monocle"),

--- a/example-js/index.html
+++ b/example-js/index.html
@@ -7,9 +7,9 @@
   <body>
     <div id="result"></div>
     <!-- Include JavaScript dependencies -->
-    <script type="text/javascript" src="./target/scala-2.11/examplejs-jsdeps.js"></script>
+    <script type="text/javascript" src="./target/scala-2.12/examplejs-jsdeps.js"></script>
     <!-- Include Scala.js compiled code -->
-    <script type="text/javascript" src="./target/scala-2.11/examplejs-fastopt.js"></script>
+    <script type="text/javascript" src="./target/scala-2.12/examplejs-fastopt.js"></script>
     <!-- Run JSApp -->
     <script type="text/javascript">
       examplejs.Main().main();

--- a/example-js/src/main/scala/examplejs/Main.scala
+++ b/example-js/src/main/scala/examplejs/Main.scala
@@ -19,7 +19,7 @@ object Main extends JSApp {
 
     implicit val interpTrans = Interpreter[IO]
 
-    case class Resp(json: String)
+    case class Resp(headers: Map[String, String], origin: String, url: String)
     case class Req(name: String, number: Int)
 
     val uri = uri"http://httpbin.org/post"


### PR DESCRIPTION
This PR fixes 2 different bugs:

1. exampleJS project was failing to link because cats-effect wasn't included for JS (it used `%%` instead of `%%%`)
2. `MatchError` when parsing empty headers from XHR response.

fixes #91 and #90