### PR TITLE
Support special characters

### DIFF
--- a/core/shared/src/main/scala/hammock/ContentType.scala
+++ b/core/shared/src/main/scala/hammock/ContentType.scala
@@ -8,7 +8,7 @@ trait ContentType {
 
 object ContentType {
   val notUsed: ContentType = fromName("")
-  val `application/json`: ContentType = fromName("application/json")
+  val `application/json`: ContentType = fromName("application/json; charset=utf-8")
   val `application/octet-stream`: ContentType= fromName("application/octet-stream")
   val `text/plain`: ContentType = fromName("application/json")
 

--- a/hammock-circe/src/main/scala/hammock/circe/CirceCodec.scala
+++ b/hammock-circe/src/main/scala/hammock/circe/CirceCodec.scala
@@ -8,14 +8,14 @@ import io.circe.syntax._
 
 class HammockEncoderForCirce[A: CirceEncoder] extends Encoder[A] {
   override def encode(a: A): Entity =
-    Entity.StringEntity(a.asJson.noSpaces)
+    Entity.StringEntity(a.asJson.noSpaces, ContentType.`application/json`)
 }
 
 class HammockDecoderForCirce[A: CirceDecoder] extends Decoder[A] {
   override def decode(entity: Entity): Either[CodecException, A] = entity match {
     case Entity.StringEntity(str, _) =>
       circeDecode[A](str).left.map(err => CodecException.withMessageAndException(err.getMessage, err))
-    case _ : Entity.ByteArrayEntity =>
+    case _: Entity.ByteArrayEntity =>
       CodecException.withMessage("unable to decode a ByteArrayEntity. Only StringEntity is supported").asLeft
   }
 }

--- a/hammock-circe/src/test/scala/hammock/circe/CirceCodecSpec.scala
+++ b/hammock-circe/src/test/scala/hammock/circe/CirceCodecSpec.scala
@@ -10,7 +10,7 @@ class CirceCodecSpec extends WordSpec with Matchers {
   import implicits._
 
   val dummyValue = Dummy(1, "patata")
-  val json       = Entity.StringEntity("""{"a":1,"b":"patata"}""")
+  val json       = Entity.StringEntity("""{"a":1,"b":"patata"}""", ContentType.`application/json`)
 
   "Codec.encode" should {
     "return the string representation of a type" in {


### PR DESCRIPTION
* Characters like Æ, Ø and Å were interpreted as `?` without explicitly passing the content type to the encoder for circe, and adding charset to the json content type.