### PR TITLE
enabled postfix operators for docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -214,7 +214,8 @@ lazy val docs = project
         Map("title" -> "changelog", "section" -> "changelog", "position" -> "99")
       )
     ),
-    scalacOptions in Tut ~= filterConsoleScalacOptions
+    scalacOptions in Tut ~= filterConsoleScalacOptions,
+    scalacOptions in Tut += "-language:postfixOps"
   )
   .enablePlugins(MicrositesPlugin)
 


### PR DESCRIPTION
The example code in the [interpreters page](http://pepegar.com/hammock/interpreters.html) in the docs are written using postfix operators, but the feature is not enabled at the project/source level, causing some verbose warning messages. 

I've enabled it at build.sbt, as it seems to me as the most unobtrusive method to remove the warnings. (the others being importing the language feature at the source scripts or removing the postfix style altogether)