### PR TITLE
add string interpolation support

### DIFF
--- a/core/shared/src/main/scala/hammock/package.scala
+++ b/core/shared/src/main/scala/hammock/package.scala
@@ -50,8 +50,13 @@ package object hammock {
       }
     }
 
-    def evaluate(interpolation: RuntimeInterpolation): Uri =
-      Uri.fromString(interpolation.literals.head).right.get
+    def evaluate(interpolation: RuntimeInterpolation): Uri ={
+      val substitued = interpolation.literals
+        .zipAll(interpolation.substitutions, "", "")
+        .map(x=>List(x._1, x._2)).flatten.mkString("")
+      Uri.fromString(substitued).right.get
+    }
+
   }
 
   implicit val embedString = UriInterpolator.embed[String](Case(UriContext, UriContext) { x => x })

--- a/core/shared/src/main/scala/hammock/package.scala
+++ b/core/shared/src/main/scala/hammock/package.scala
@@ -51,10 +51,10 @@ package object hammock {
     }
 
     def evaluate(interpolation: RuntimeInterpolation): Uri ={
-      val substitued = interpolation.literals
+      val substituted = interpolation.literals
         .zipAll(interpolation.substitutions, "", "")
-        .map(x=>List(x._1, x._2)).flatten.mkString("")
-      Uri.fromString(substitued).right.get
+        .flatMap(x=>List(x._1, x._2)).mkString("")
+      Uri.fromString(substituted).right.get
     }
 
   }

--- a/core/shared/src/test/scala/hammock/UriProps.scala
+++ b/core/shared/src/test/scala/hammock/UriProps.scala
@@ -30,6 +30,13 @@ object UriProps extends Properties("Uri") {
     query.contains(key) && query(key) === value
   }
 
+  property("string interpolation") = forAll(nonEmptyAlphanumString, nonEmptyAlphanumString, nonEmptyAlphanumString, nonEmptyAlphanumString, nonEmptyAlphanumString) { (url: String, key1: String, value1: String, key2: String, value2: String) =>
+    val substituedUri = uri"https://${url}?${key1}=${value1}&${key2}=${value2}&other=query"
+    substituedUri.query.contains(key1) && substituedUri.query(key1) === value1
+    substituedUri.query.contains(key2) && substituedUri.query(key2) === value2
+    substituedUri.show == s"https://${url}?${key1}=${value1}&${key2}=${value2}&other=query"
+  }
+
   property("params method appends multiple parameters to the query") = forAll(uriArbitrary.arbitrary, Gen.listOf(nonEmptyStringPair)) { (uri, pairs) =>
     val query = uri.params(pairs: _*).query
     Foldable[List].foldLeft(pairs.map(pair => query.contains(pair._1)), true)(_ && _)


### PR DESCRIPTION
currently behavior of `uri"http://url?param=${something}"` will only construct
a uri `http://url?param=` and drop everything after

I think it should keep the same bahvior as other string
interpolation such as `s""` or doobie's `sql""` otherwise it's really confusing