### PR TITLE
Support fetch api from browser, not just node

### DIFF
--- a/core/js/src/test/scala/hammock/fetch/InterpreterSpec.scala
+++ b/core/js/src/test/scala/hammock/fetch/InterpreterSpec.scala
@@ -1,5 +1,5 @@
 package hammock
-package node
+package fetch
 
 import cats.effect.IO
 import org.scalatest.{AsyncFlatSpec, Matchers}

--- a/example-node/src/main/scala/examplenode/Main.scala
+++ b/example-node/src/main/scala/examplenode/Main.scala
@@ -1,7 +1,7 @@
 package examplenode
 
 import hammock._
-import hammock.node._
+import hammock.fetch._
 import hammock.marshalling._
 import hammock.circe.implicits._
 import io.circe.generic.auto._


### PR DESCRIPTION
This PR allows the use of the browser fetch api (https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) as well as the one imported from node. This is the same API as the node one but found in a different place (the browser).

Most scala-js users won't require this (though it won't hurt them either), but it helps with react-native applications which only support fetch, not XHR.

I tested at the following PR: https://github.com/triggerNZ/scalajs-react-native/pull/4, and it does seem to work.

Given that the interpreter is now not specific to node, i renamed the package from `node` to `fetch`. I am happy to update the documentation, but this is my first PR to hammock so before going too far, I'd like to get some feedback about whether this change is acceptable.
