### PR TITLE
update cats & downstream dependencies

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,10 @@
+pull_request_rules:
+  - name: automatically merge scala-steward's PRs
+    conditions:
+      - author=scala-steward
+      - status-success=Travis CI - Pull Request
+    actions:
+      merge:
+        method: merge
+      label:
+        add: [dependency-update]

--- a/build.sbt
+++ b/build.sbt
@@ -18,21 +18,24 @@ inThisBuild(
   ))
 
 val Versions = Map(
-  "contextual"     -> "1.1.0",
-  "circe"          -> "0.11.1",
-  "monocle"        -> "1.5.1-cats",
-  "atto"           -> "0.6.5",
-  "cats"           -> "1.6.1",
-  "cats-effect"    -> "1.3.1",
-  "simulacrum"     -> "0.19.0",
-  "scalatest"      -> "3.0.5",
-  "scalacheck"     -> "1.14.0",
-  "discipline"     -> "0.11.1",
-  "macro-paradise" -> "2.1.1",
-  "kind-projector" -> "0.9.10",
-  "akka-http"      -> "10.0.15",
-  "ahc"            -> "2.1.2",
-  "mockito"        -> "1.10.19"
+  "contextual"              -> "1.1.0",
+  "circe"                   -> "0.12.1",
+  "monocle"                 -> "2.0.0",
+  "atto"                    -> "0.7.0",
+  "cats"                    -> "2.0.0",
+  "cats-effect"             -> "2.0.0",
+  "simulacrum"              -> "0.19.0",
+  "scalatest"               -> "3.1.0-SNAP13",
+  "scalacheck"              -> "1.14.0",
+  "scalatestplusScalaCheck" -> "1.0.0-SNAP8",
+  "scalatestplusMockito"    -> "1.0.0-M2",
+  "discipline"              -> "1.0.0",
+  "macro-paradise"          -> "2.1.1",
+  "kind-projector"          -> "0.9.10",
+  "akka-http"               -> "10.0.15",
+  "ahc"                     -> "2.1.2",
+  "apacheHttp"              -> "4.5.9",
+  "mockito"                 -> "1.10.19"
 )
 
 val noPublishSettings = Seq(
@@ -54,21 +57,22 @@ val buildSettings = Seq(
 
 val commonDependencies = Seq(
   libraryDependencies ++= Seq(
-    "org.typelevel"              %%% "cats-core"      % Versions("cats"),
-    "org.typelevel"              %%% "cats-free"      % Versions("cats"),
-    "org.typelevel"              %%% "alleycats-core" % Versions("cats"),
-    "com.propensive"             %%% "contextual"     % Versions("contextual"),
-    "org.typelevel"              %%% "cats-effect"    % Versions("cats-effect"),
-    "com.github.mpilquist"       %%% "simulacrum"     % Versions("simulacrum"),
-    "com.github.julien-truffaut" %%% "monocle-core"   % Versions("monocle"),
-    "com.github.julien-truffaut" %%% "monocle-macro"  % Versions("monocle"),
-    "org.tpolecat"               %%% "atto-core"      % Versions("atto"),
-    "com.github.julien-truffaut" %%% "monocle-law"    % Versions("monocle") % Test,
-    "org.typelevel"              %%% "cats-laws"      % Versions("cats") % Test,
-    "org.typelevel"              %%% "cats-testkit"   % Versions("cats") % Test,
-    "org.scalatest"              %%% "scalatest"      % Versions("scalatest") % Test,
-    "org.scalacheck"             %%% "scalacheck"     % Versions("scalacheck") % Test,
-    "org.typelevel"              %%% "discipline"     % Versions("discipline") % Test
+    "org.typelevel"              %%% "cats-core"                % Versions("cats"),
+    "org.typelevel"              %%% "cats-free"                % Versions("cats"),
+    "org.typelevel"              %%% "alleycats-core"           % Versions("cats"),
+    "com.propensive"             %%% "contextual"               % Versions("contextual"),
+    "org.typelevel"              %%% "cats-effect"              % Versions("cats-effect"),
+    "com.github.mpilquist"       %%% "simulacrum"               % Versions("simulacrum"),
+    "com.github.julien-truffaut" %%% "monocle-core"             % Versions("monocle"),
+    "com.github.julien-truffaut" %%% "monocle-macro"            % Versions("monocle"),
+    "org.tpolecat"               %%% "atto-core"                % Versions("atto"),
+    "com.github.julien-truffaut" %%% "monocle-law"              % Versions("monocle") % Test,
+    "org.typelevel"              %%% "cats-laws"                % Versions("cats") % Test,
+    "org.typelevel"              %%% "cats-testkit"             % Versions("cats") % Test,
+    "org.scalatest"              %%% "scalatest"                % Versions("scalatest") % Test,
+    "org.scalacheck"             %%% "scalacheck"               % Versions("scalacheck") % Test,
+    "org.scalatestplus"          %%% "scalatestplus-scalacheck" % Versions("scalatestplusScalaCheck") % Test,
+    "org.typelevel"              %%% "discipline-core"          % Versions("discipline") % Test
   )
 )
 
@@ -130,10 +134,11 @@ lazy val apache = project
   .settings(compilerPlugins)
   .settings(
     libraryDependencies ++= Seq(
-      "org.apache.httpcomponents" % "httpclient" % "4.5.9"
+      "org.apache.httpcomponents" % "httpclient"              % Versions("apacheHttp"),
+      "org.scalatestplus"         %%% "scalatestplus-mockito" % Versions("scalatestplusMockito") % Test,
+      "org.mockito"               % "mockito-all"             % Versions("mockito") % Test
     )
   )
-  .settings(libraryDependencies += "org.mockito" % "mockito-all" % Versions("mockito") % Test)
   .dependsOn(coreJVM)
 
 lazy val akka = project
@@ -143,9 +148,12 @@ lazy val akka = project
   .settings(commonDependencies)
   .settings(compilerPlugins)
   .settings(
-    libraryDependencies += "com.typesafe.akka" %% "akka-http" % Versions("akka-http")
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-http"              % Versions("akka-http"),
+      "org.mockito"       % "mockito-all"             % Versions("mockito") % Test,
+      "org.scalatestplus" %%% "scalatestplus-mockito" % Versions("scalatestplusMockito") % Test
+    )
   )
-  .settings(libraryDependencies += "org.mockito" % "mockito-all" % Versions("mockito") % Test)
   .dependsOn(coreJVM)
 
 lazy val asynchttpclient = project
@@ -155,9 +163,12 @@ lazy val asynchttpclient = project
   .settings(commonDependencies)
   .settings(compilerPlugins)
   .settings(
-    libraryDependencies += "org.asynchttpclient" % "async-http-client" % Versions("ahc")
+    libraryDependencies ++= Seq(
+      "org.asynchttpclient" % "async-http-client"       % Versions("ahc"),
+      "org.scalatestplus"   %%% "scalatestplus-mockito" % Versions("scalatestplusMockito") % Test,
+      "org.mockito"         % "mockito-all"             % Versions("mockito") % Test
+    )
   )
-  .settings(libraryDependencies += "org.mockito" % "mockito-all" % Versions("mockito") % Test)
   .dependsOn(coreJVM)
 
 lazy val javadocIoUrl = settingKey[String]("the url of hammock documentation in http://javadoc.io")

--- a/build.sbt
+++ b/build.sbt
@@ -18,23 +18,24 @@ inThisBuild(
   ))
 
 val Versions = Map(
-  "contextual"              -> "1.1.0",
+  "contextual"              -> "1.2.1",
   "circe"                   -> "0.12.1",
   "monocle"                 -> "2.0.0",
-  "atto"                    -> "0.7.0",
+  "atto"                    -> "0.7.1",
   "cats"                    -> "2.0.0",
   "cats-effect"             -> "2.0.0",
-  "simulacrum"              -> "0.19.0",
-  "scalatest"               -> "3.1.0-SNAP13",
-  "scalacheck"              -> "1.14.0",
-  "scalatestplusScalaCheck" -> "1.0.0-SNAP8",
-  "scalatestplusMockito"    -> "1.0.0-M2",
-  "discipline"              -> "1.0.0",
+  "simulacrum"              -> "1.0.0",
+  "scalatest"               -> "3.2.0-M1",
+  "scalacheck"              -> "1.14.2",
+  "scalatestplusScalaCheck" -> "3.1.0.0-RC2",
+  "scalatestplusMockito"    -> "1.0.0-SNAP5",
+  "discipline"              -> "1.0.1",
   "macro-paradise"          -> "2.1.1",
-  "kind-projector"          -> "0.9.10",
-  "akka-http"               -> "10.0.15",
-  "ahc"                     -> "2.1.2",
-  "apacheHttp"              -> "4.5.9",
+  "kind-projector"          -> "0.10.3",
+  "akka-http"               -> "10.1.10",
+  "akka-stream"             -> "2.5.23",
+  "ahc"                     -> "2.10.3",
+  "apacheHttp"              -> "4.5.10",
   "mockito"                 -> "1.10.19"
 )
 
@@ -47,9 +48,8 @@ val noPublishSettings = Seq(
 
 val buildSettings = Seq(
   organization := "com.pepegar",
-  scalaVersion := "2.12.5",
+  scalaVersion := "2.12.10",
   licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT"))),
-  crossScalaVersions := Seq("2.11.12", scalaVersion.value),
   scalacOptions in (Compile, console) ~= filterConsoleScalacOptions,
   scalacOptions in (Compile, doc) ~= filterConsoleScalacOptions,
   scalafmtOnCompile in ThisBuild := true
@@ -62,7 +62,7 @@ val commonDependencies = Seq(
     "org.typelevel"              %%% "alleycats-core"           % Versions("cats"),
     "com.propensive"             %%% "contextual"               % Versions("contextual"),
     "org.typelevel"              %%% "cats-effect"              % Versions("cats-effect"),
-    "com.github.mpilquist"       %%% "simulacrum"               % Versions("simulacrum"),
+    "org.typelevel"              %%% "simulacrum"               % Versions("simulacrum"),
     "com.github.julien-truffaut" %%% "monocle-core"             % Versions("monocle"),
     "com.github.julien-truffaut" %%% "monocle-macro"            % Versions("monocle"),
     "org.tpolecat"               %%% "atto-core"                % Versions("atto"),
@@ -79,7 +79,7 @@ val commonDependencies = Seq(
 val compilerPlugins = Seq(
   libraryDependencies ++= Seq(
     compilerPlugin("org.scalamacros" %% "paradise"       % Versions("macro-paradise") cross CrossVersion.full),
-    compilerPlugin("org.spire-math"  %% "kind-projector" % Versions("kind-projector"))
+    compilerPlugin("org.typelevel"   %% "kind-projector" % Versions("kind-projector"))
   )
 )
 
@@ -150,6 +150,7 @@ lazy val akka = project
   .settings(
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-http"              % Versions("akka-http"),
+      "com.typesafe.akka" %% "akka-stream"            % Versions("akka-stream"),
       "org.mockito"       % "mockito-all"             % Versions("mockito") % Test,
       "org.scalatestplus" %%% "scalatestplus-mockito" % Versions("scalatestplusMockito") % Test
     )

--- a/core/js/src/main/scala/hammock/fetch/Interpreter.scala
+++ b/core/js/src/main/scala/hammock/fetch/Interpreter.scala
@@ -1,8 +1,10 @@
 package hammock
 package fetch
 
+import cats.~>
 import cats.effect._
-import cats._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import io.scalajs.npm.nodefetch._
 import scala.scalajs.js.Promise
 import cats.syntax.show._
@@ -12,7 +14,7 @@ object Interpreter {
 
   def apply[F[_]](implicit F: InterpTrans[F]): InterpTrans[F] = F
 
-  implicit def instance[F[_]: Async](
+  implicit def instance[F[_]: Async: ContextShift](
       implicit nodeFetch: NodeFetch = io.scalajs.npm.nodefetch.NodeFetch): InterpTrans[F] = new InterpTrans[F] {
 
     def trans: HttpF ~> F = new (HttpF ~> F) {
@@ -29,8 +31,8 @@ object Interpreter {
         }
         http match {
           case Get(_) | Options(_) | Delete(_) | Head(_) | Options(_) | Trace(_) | Post(_) | Put(_) | Patch(_) =>
-            val hammockResponse = for {
-              response <- IO.fromFuture(IO {
+            for {
+              response <- Async.fromFuture(Async[F].delay {
                 val headers = http.req.headers.toJSDictionary
                 nodeFetch(
                   http.req.uri.show,
@@ -49,9 +51,8 @@ object Interpreter {
                       ))
                 ).toFuture
               })
-              entity <- IO.fromFuture(IO(response.text().asInstanceOf[Promise[String]].toFuture))
+              entity <- Async.fromFuture(Async[F].delay(response.text().asInstanceOf[Promise[String]].toFuture))
             } yield HttpResponse(Status.Statuses(response.status), response.headers.toMap, Entity.StringEntity(entity))
-            hammockResponse.to[F]
         }
       }
     }

--- a/core/js/src/main/scala/hammock/fetch/Interpreter.scala
+++ b/core/js/src/main/scala/hammock/fetch/Interpreter.scala
@@ -41,7 +41,7 @@ object Interpreter {
                       _.cata(
                         string => Some(string.content),
                         bytes => Some(bytes.content.map(_.toChar).mkString),
-                        empty => None
+                        _ => None
                       ))
                     .map(body => new RequestOptions(body = body, headers = headers, method = method.name))
                     .getOrElse(

--- a/core/js/src/test/scala/hammock/fetch/InterpreterSpec.scala
+++ b/core/js/src/test/scala/hammock/fetch/InterpreterSpec.scala
@@ -2,7 +2,7 @@ package hammock
 package fetch
 
 import cats.effect.IO
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AsyncFlatSpec
 import scala.concurrent.ExecutionContextExecutor
 import Interpreter._

--- a/core/shared/src/main/scala/hammock/Status.scala
+++ b/core/shared/src/main/scala/hammock/Status.scala
@@ -7,10 +7,10 @@ import monocle.macros.Lenses
 
 @Lenses case class Status(code: Int, text: String, description: String) {
   def isInformational: Boolean = this.code / 100 == 1
-  def isSuccess: Boolean = this.code / 100 == 2
-  def isRedirection: Boolean = this.code / 100 == 3
-  def isClientError: Boolean = this.code / 100 == 4
-  def isServerError: Boolean = this.code / 100 == 5
+  def isSuccess: Boolean       = this.code / 100 == 2
+  def isRedirection: Boolean   = this.code / 100 == 3
+  def isClientError: Boolean   = this.code / 100 == 4
+  def isServerError: Boolean   = this.code / 100 == 5
 }
 
 object Status {
@@ -118,9 +118,10 @@ object Status {
     422,
     "Unprocessable Entity",
     "The request was well-formed but was unable to be followed due to semantic errors.")
-  val Locked               = Status(423, "Locked", "The resource that is being accessed is locked.")
-  val FailedDependency     = Status(424, "Failed Dependency", "The request failed due to failure of a previous request.")
-  val UnorderedCollection  = Status(425, "Unordered Collection", "The collection is unordered.")
+  val Locked           = Status(423, "Locked", "The resource that is being accessed is locked.")
+  val FailedDependency = Status(424, "Failed Dependency", "The request failed due to failure of a previous request.")
+  val TooEarly =
+    Status(425, "Too Early", "The server is unwilling to risk processing a request that might be replayed.")
   val UpgradeRequired      = Status(426, "Upgrade Required", "The client should switch to a different protocol.")
   val PreconditionRequired = Status(428, "Precondition Required", "The server requires the request to be conditional.")
   val TooManyRequests =
@@ -218,7 +219,7 @@ object Status {
     422 -> UnprocessableEntity,
     423 -> Locked,
     424 -> FailedDependency,
-    425 -> UnorderedCollection,
+    425 -> TooEarly,
     426 -> UpgradeRequired,
     428 -> PreconditionRequired,
     429 -> TooManyRequests,
@@ -245,5 +246,5 @@ object Status {
   def get(code: Int): Status = Statuses.getOrElse(code, Status(code, "Undefined", "Undefined StatusCode"))
 
   implicit val show: Show[Status] = Show[Int].contramap(_.code)
-  implicit val eq: Eq[Status] = Eq.fromUniversalEquals
+  implicit val eq: Eq[Status]     = Eq.fromUniversalEquals
 }

--- a/core/shared/src/main/scala/hammock/package.scala
+++ b/core/shared/src/main/scala/hammock/package.scala
@@ -4,82 +4,81 @@ import cats.free.Free
 import cats.effect.Sync
 import contextual._
 
-
 package object hammock {
 
   import hammock.marshalling._
   import hammock.InterpTrans
 
-
   type HammockF[A] = EitherK[HttpF, MarshallF, A]
 
   implicit class HttpRequestIOSyntax[A](fa: Free[HttpF, A]) {
-    def exec[F[_] : Sync](implicit interp: InterpTrans[F]): F[A] =
+    def exec[F[_]: Sync](implicit interp: InterpTrans[F]): F[A] =
       fa foldMap interp.trans
   }
 
   implicit class HammockFSyntax[A](fa: Free[HammockF, A]) {
-    def exec[F[_] : Sync](implicit NT: HammockF ~> F): F[A] =
+    def exec[F[_]: Sync](implicit NT: HammockF ~> F): F[A] =
       fa foldMap NT
   }
 
-
-  implicit class AsSyntaxOnHttpF[F[_], A](fa: Free[F, HttpResponse])(implicit
-    H: InjectK[HttpF, F]
-  ) {
-    def as[B](implicit D: Decoder[B], M: MarshallC[EitherK[F, MarshallF, ?]]): Free[EitherK[F, MarshallF, ?], B] =
-      fa.inject[EitherK[F, MarshallF, ?]] flatMap { response =>
+  implicit class AsSyntaxOnHttpF[F[_], A](fa: Free[F, HttpResponse])(
+      implicit
+      H: InjectK[HttpF, F]) {
+    def as[B](implicit D: Decoder[B], M: MarshallC[EitherK[F, MarshallF, *]]): Free[EitherK[F, MarshallF, *], B] =
+      fa.inject[EitherK[F, MarshallF, *]] flatMap { response =>
         M.unmarshall(response.entity)
       }
   }
 
-  implicit def hammockNT[F[_] : Sync](
-                                       implicit H: InterpTrans[F],
-                                       M: MarshallF ~> F
-                                     ): HammockF ~> F = H.trans or M
-
+  implicit def hammockNT[F[_]: Sync](
+      implicit H: InterpTrans[F],
+      M: MarshallF ~> F
+  ): HammockF ~> F = H.trans or M
 
   object UriContext extends Context
 
   object UriInterpolator extends Interpolator {
-    type Output = Uri
+    type Output      = Uri
     type ContextType = UriContext.type
-    type Input = String
+    type Input       = String
     def contextualize(interpolation: StaticInterpolation) = {
       interpolation.parts.foldLeft(List.empty[ContextType]) {
         case (contexts, Hole(_, _)) => UriContext :: contexts
-        case (contexts, _) => contexts
+        case (contexts, _)          => contexts
       }
     }
 
-    def evaluate(interpolation: RuntimeInterpolation): Uri ={
+    def evaluate(interpolation: RuntimeInterpolation): Uri = {
       val substituted = interpolation.literals
         .zipAll(interpolation.substitutions, "", "")
-        .flatMap(x=>List(x._1, x._2)).mkString("")
+        .flatMap(x => List(x._1, x._2))
+        .mkString("")
       Uri.fromString(substituted).right.get
     }
 
   }
 
-  implicit val embedString = UriInterpolator.embed[String](Case(UriContext, UriContext) { x => x })
+  implicit val embedString = UriInterpolator.embed[String](Case(UriContext, UriContext) { x =>
+    x
+  })
 
   /**
-    * Unsafe string interpolator allowing uri parsing.  It's unsafe
-    * because in case of any error happen (a Left is returned by the
-    * `fromString` method), it will throw an exception.
-    *
-    * {{{
-    * scala> uri"http://user:pass@pepegar.com/path?page=4#index"
-    * res1: hammock.Uri = Uri(Some(http),Some(user:pass),pepegar.com/path,Map(page -> 4),Some(index))
-    * }}}
-    */
+   * Unsafe string interpolator allowing uri parsing.  It's unsafe
+   * because in case of any error happen (a Left is returned by the
+   * `fromString` method), it will throw an exception.
+   *
+   * {{{
+   * scala> uri"http://user:pass@pepegar.com/path?page=4#index"
+   * res1: hammock.Uri = Uri(Some(http),Some(user:pass),pepegar.com/path,Map(page -> 4),Some(index))
+   * }}}
+   */
   implicit class UriStringContext(sc: StringContext) {
     val uri = Prefix(UriInterpolator, sc)
   }
 
   /**
-    * Methods providing URI query parameters building syntax
-    * Used in [[Uri.?]] method
+   * Methods providing URI query parameters building syntax
+   * Used in [[Uri.?]] method
     **/
   implicit class UriQueryParamsBuilder(val self: NonEmptyList[(String, String)]) extends AnyVal {
     def &(param: (String, String)): NonEmptyList[(String, String)] = param :: self

--- a/core/shared/src/test/scala/hammock/CodecSpec.scala
+++ b/core/shared/src/test/scala/hammock/CodecSpec.scala
@@ -8,7 +8,8 @@ import cats.laws.discipline._
 import cats.syntax.either._
 
 import org.scalacheck.{Arbitrary, Prop}
-import org.scalatest._
+import org.scalatest.Matchers
+import org.scalatest.funsuite.AnyFunSuite
 import org.typelevel.discipline.Laws
 import org.typelevel.discipline.scalatest.Discipline
 
@@ -42,7 +43,7 @@ object CodecTests {
 
 }
 
-class CodecSpec extends FunSuite with Discipline with Matchers {
+class CodecSpec extends AnyFunSuite with Discipline with Matchers {
   import Encoder.ops._
 
   implicit val intCodec = new Codec[Int] {

--- a/core/shared/src/test/scala/hammock/CodecSpec.scala
+++ b/core/shared/src/test/scala/hammock/CodecSpec.scala
@@ -8,7 +8,7 @@ import cats.laws.discipline._
 import cats.syntax.either._
 
 import org.scalacheck.{Arbitrary, Prop}
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite.AnyFunSuite
 import org.typelevel.discipline.Laws
 import org.typelevel.discipline.scalatest.Discipline
@@ -37,7 +37,7 @@ trait CodecTests[A] extends Laws {
 
 object CodecTests {
 
-  def apply[A: Codec : Arbitrary : Eq]: CodecTests[A] = new CodecTests[A] {
+  def apply[A: Codec: Arbitrary: Eq]: CodecTests[A] = new CodecTests[A] {
     def laws: CodecLaws[A] = CodecLaws[A]
   }
 

--- a/core/shared/src/test/scala/hammock/ContentTypeSpec.scala
+++ b/core/shared/src/test/scala/hammock/ContentTypeSpec.scala
@@ -1,6 +1,6 @@
 package hammock
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class ContentTypeSpec extends AnyWordSpec with Matchers {
@@ -16,7 +16,7 @@ class ContentTypeSpec extends AnyWordSpec with Matchers {
 
     "not equal ContentType instances" in {
       val applicationJson = ContentType.`application/json`
-      val textPlain = ContentType.`text/plain`
+      val textPlain       = ContentType.`text/plain`
 
       assert(applicationJson != textPlain)
     }

--- a/core/shared/src/test/scala/hammock/ContentTypeSpec.scala
+++ b/core/shared/src/test/scala/hammock/ContentTypeSpec.scala
@@ -1,8 +1,9 @@
 package hammock
 
-import org.scalatest._
+import org.scalatest.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ContentTypeSpec extends WordSpec with Matchers {
+class ContentTypeSpec extends AnyWordSpec with Matchers {
 
   "Eq[ContentType]" should {
 

--- a/core/shared/src/test/scala/hammock/EntitySpec.scala
+++ b/core/shared/src/test/scala/hammock/EntitySpec.scala
@@ -1,7 +1,7 @@
 package hammock
 
 import hammock.Entity._
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class EntitySpec extends AnyWordSpec with Matchers {
@@ -42,7 +42,7 @@ class EntitySpec extends AnyWordSpec with Matchers {
   "Eq[Entity]" should {
 
     "equal instance" in {
-      val body = "body".getBytes
+      val body        = "body".getBytes
       val instanceOne = ByteArrayEntity(body)
       val instanceTwo = ByteArrayEntity(body)
       assert(instanceOne == instanceTwo)

--- a/core/shared/src/test/scala/hammock/EntitySpec.scala
+++ b/core/shared/src/test/scala/hammock/EntitySpec.scala
@@ -1,9 +1,10 @@
 package hammock
 
 import hammock.Entity._
-import org.scalatest._
+import org.scalatest.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class EntitySpec extends WordSpec with Matchers {
+class EntitySpec extends AnyWordSpec with Matchers {
 
   "EmptyEntity" should {
 

--- a/core/shared/src/test/scala/hammock/HammockSpec.scala
+++ b/core/shared/src/test/scala/hammock/HammockSpec.scala
@@ -1,18 +1,18 @@
 package hammock
 
-
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import cats._
-import hi.{Cookie, Opts, Auth}
+import hi.{Auth, Cookie, Opts}
 
 class HammockSpec extends AnyWordSpec with Matchers {
-  val methods = Seq(Method.OPTIONS, Method.GET, Method.HEAD, Method.POST, Method.PUT, Method.DELETE, Method.TRACE, Method.PATCH)
+  val methods =
+    Seq(Method.OPTIONS, Method.GET, Method.HEAD, Method.POST, Method.PUT, Method.DELETE, Method.TRACE, Method.PATCH)
 
   implicit val stringCodec = new Codec[String] {
-    def decode(a: hammock.Entity): Either[hammock.CodecException,String] = a match {
+    def decode(a: hammock.Entity): Either[hammock.CodecException, String] = a match {
       case Entity.StringEntity(str, _) => Right(str)
-      case _ => Left(CodecException.withMessage("expected string entity"))
+      case _                           => Left(CodecException.withMessage("expected string entity"))
     }
     def encode(a: String): hammock.Entity = Entity.StringEntity(a)
   }
@@ -65,8 +65,8 @@ class HammockSpec extends AnyWordSpec with Matchers {
 
     "construct the correct headers" in {
       val basicAuth = Auth.BasicAuth("user", "p4ssw0rd")
-      val opts = Opts(Option(basicAuth), Map.empty, Option.empty)
-      val shown = Show[Auth].show(basicAuth)
+      val opts      = Opts(Option(basicAuth), Map.empty, Option.empty)
+      val shown     = Show[Auth].show(basicAuth)
 
       Uri.fromString("http://pepegar.com") match {
         case Right(uri) =>

--- a/core/shared/src/test/scala/hammock/HammockSpec.scala
+++ b/core/shared/src/test/scala/hammock/HammockSpec.scala
@@ -1,11 +1,12 @@
 package hammock
 
 
-import org.scalatest._
+import org.scalatest.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import cats._
 import hi.{Cookie, Opts, Auth}
 
-class HammockSpec extends WordSpec with Matchers {
+class HammockSpec extends AnyWordSpec with Matchers {
   val methods = Seq(Method.OPTIONS, Method.GET, Method.HEAD, Method.POST, Method.PUT, Method.DELETE, Method.TRACE, Method.PATCH)
 
   implicit val stringCodec = new Codec[String] {

--- a/core/shared/src/test/scala/hammock/StatusSpec.scala
+++ b/core/shared/src/test/scala/hammock/StatusSpec.scala
@@ -1,6 +1,6 @@
 package hammock
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class StatusSpec extends AnyWordSpec with Matchers {

--- a/core/shared/src/test/scala/hammock/StatusSpec.scala
+++ b/core/shared/src/test/scala/hammock/StatusSpec.scala
@@ -1,8 +1,9 @@
 package hammock
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class StatusSpec extends WordSpec with Matchers {
+class StatusSpec extends AnyWordSpec with Matchers {
   val status: Int => Status = (code: Int) => Status(code, "", "")
 
   "Status.isInformational" when {

--- a/core/shared/src/test/scala/hammock/TestInstances.scala
+++ b/core/shared/src/test/scala/hammock/TestInstances.scala
@@ -11,14 +11,18 @@ object TestInstances {
   import Uri._
   import Host._
 
-  val nonEmptyString: Gen[String] = Gen.nonEmptyListOf(Gen.oneOf {
-    Seq('!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~') ++
-      ('0' to '9') ++ ('A' to 'Z') ++ ('a' to 'z')
-  }).map(_.mkString)
+  val nonEmptyString: Gen[String] = Gen
+    .nonEmptyListOf(Gen.oneOf {
+      Seq('!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~') ++
+        ('0' to '9') ++ ('A' to 'Z') ++ ('a' to 'z')
+    })
+    .map(_.mkString)
 
-  val nonEmptyAlphanumString: Gen[String] = Gen.nonEmptyListOf(Gen.oneOf {
-    ('0' to '9') ++ ('a' to 'z') ++ ('A' to 'Z')
-  }).map(_.mkString)
+  val nonEmptyAlphanumString: Gen[String] = Gen
+    .nonEmptyListOf(Gen.oneOf {
+      ('0' to '9') ++ ('a' to 'z') ++ ('A' to 'Z')
+    })
+    .map(_.mkString)
 
   val nonEmptyStringPair: Gen[(String, String)] = for {
     k <- nonEmptyAlphanumString
@@ -51,7 +55,8 @@ object TestInstances {
 
   val localHostGen = Gen.const(Host.Localhost).label("Localhost")
 
-  implicit val hostArbitrary: Arbitrary[Host] = Arbitrary(Gen.oneOf(ipv4Gen, ipv6Gen, otherGen, localHostGen).label("Host"))
+  implicit val hostArbitrary: Arbitrary[Host] = Arbitrary(
+    Gen.oneOf(ipv4Gen, ipv6Gen, otherGen, localHostGen).label("Host"))
 
   implicit val authorityArbitrary: Arbitrary[Authority] = Arbitrary((for {
     user <- Gen.option(nonEmptyAlphanumString)
@@ -60,11 +65,11 @@ object TestInstances {
   } yield Authority(user, host, port)).label("Authority"))
 
   implicit val uriArbitrary: Arbitrary[Uri] = Arbitrary((for {
-    scheme <- Gen.some(Gen.oneOf("http", "https", "ftp", "ws"))
+    scheme    <- Gen.some(Gen.oneOf("http", "https", "ftp", "ws"))
     authority <- Gen.some(authorityArbitrary.arbitrary)
-    path <- Gen.alphaNumStr.map(_.mkString("/", "/", ""))
-    query <- Gen.mapOf(nonEmptyStringPair)
-    fragment <- Gen.option(nonEmptyAlphanumString)
+    path      <- Gen.alphaNumStr.map(_.mkString("/", "/", ""))
+    query     <- Gen.mapOf(nonEmptyStringPair)
+    fragment  <- Gen.option(nonEmptyAlphanumString)
   } yield Uri(scheme, authority, path, query, fragment)).label("Uri"))
 
   implicit val uriCogen: Cogen[Uri] =
@@ -78,66 +83,74 @@ object TestInstances {
   }
 
   implicit val authArbitrary: Arbitrary[Auth] = Arbitrary(
-    Gen.oneOf(
-      nonEmptyString.map(OAuth2Bearer),
-      nonEmptyString.map(OAuth2Token),
-      (nonEmptyString, nonEmptyString).mapN(BasicAuth)
-    ).label("Auth")
+    Gen
+      .oneOf(
+        nonEmptyString.map(OAuth2Bearer),
+        nonEmptyString.map(OAuth2Token),
+        (nonEmptyString, nonEmptyString).mapN(BasicAuth)
+      )
+      .label("Auth")
   )
 
   implicit val authCogen: Cogen[Auth] = Cogen[String].contramap[Auth](_.show)
 
-  implicit val sameSiteArbitrary: Arbitrary[SameSite] = Arbitrary(Gen.oneOf(SameSite.Lax, SameSite.Strict).label("SameSite"))
+  implicit val sameSiteArbitrary: Arbitrary[SameSite] = Arbitrary(
+    Gen.oneOf(SameSite.Lax, SameSite.Strict).label("SameSite"))
 
-  implicit val sameSiteCogen: Cogen[SameSite] = Cogen[Boolean].contramap[SameSite](_ match {
-    case SameSite.Lax => true
+  implicit val sameSiteCogen: Cogen[SameSite] = Cogen[Boolean].contramap[SameSite] {
+    case SameSite.Lax    => true
     case SameSite.Strict => true
-  })
+  }
 
   implicit val mapArbitrary: Arbitrary[Map[String, String]] = Arbitrary(
-    Gen.frequency(
-      1 -> Gen.const(Map.empty[String, String]),
-      5 -> Gen.choose(1, 50).flatMap(x => Gen.mapOfN(x, nonEmptyStringPair))
-    ).label("Map[String, String]")
+    Gen
+      .frequency(
+        1 -> Gen.const(Map.empty[String, String]),
+        5 -> Gen.choose(1, 50).flatMap(x => Gen.mapOfN(x, nonEmptyStringPair))
+      )
+      .label("Map[String, String]")
   )
 
   implicit val cookieCogen: Cogen[Cookie] =
-    Cogen.tuple9[
-    String,
-    String,
-    Option[Int],
-    Option[String],
-    Option[String],
-    Option[Boolean],
-    Option[Boolean],
-    Option[SameSite],
-      Option[Map[String, String]]].contramap[Cookie] { c =>
-      (c.name, c.value, c.maxAge, c.domain, c.path, c.secure, c.httpOnly, c.sameSite, c.custom)
-    }
+    Cogen
+      .tuple9[
+        String,
+        String,
+        Option[Int],
+        Option[String],
+        Option[String],
+        Option[Boolean],
+        Option[Boolean],
+        Option[SameSite],
+        Option[Map[String, String]]]
+      .contramap[Cookie] { c =>
+        (c.name, c.value, c.maxAge, c.domain, c.path, c.secure, c.httpOnly, c.sameSite, c.custom)
+      }
 
   // TODO: we should add generator for custom too, but I cannot make it work correctly
   implicit val cookieArbitrary: Arbitrary[Cookie] = Arbitrary(
     (for {
-      name <- nonEmptyString
-      value <- nonEmptyString
-      expires <- Gen.const(None)
-      maxAge <- Gen.option(Gen.choose(0, Int.MaxValue))
-      domain <- Gen.option(nonEmptyString)
-      path <- Gen.option(nonEmptyString)
-      secure <- Gen.option(Gen.oneOf(true, false))
+      name     <- nonEmptyString
+      value    <- nonEmptyString
+      expires  <- Gen.const(None)
+      maxAge   <- Gen.option(Gen.choose(0, Int.MaxValue))
+      domain   <- Gen.option(nonEmptyString)
+      path     <- Gen.option(nonEmptyString)
+      secure   <- Gen.option(Gen.oneOf(true, false))
       httpOnly <- Gen.option(Gen.oneOf(true, false))
       sameSite <- Gen.option(sameSiteArbitrary.arbitrary)
-      custom <- Gen.option(Gen.mapOf(nonEmptyStringPair))
-    } yield Cookie(name, value, expires, maxAge, domain, path, secure, httpOnly, sameSite)).label("Cookie")
+      custom   <- Gen.option(Gen.mapOf(nonEmptyStringPair))
+    } yield Cookie(name, value, expires, maxAge, domain, path, secure, httpOnly, sameSite, custom)).label("Cookie")
   )
 
-  implicit val optsCogen: Cogen[Opts] = Cogen.tuple3[Option[Auth], Map[String, String], Option[List[Cookie]]].contramap[Opts] { o =>
-    (o.auth, o.headers, o.cookies)
-  }
+  implicit val optsCogen: Cogen[Opts] =
+    Cogen.tuple3[Option[Auth], Map[String, String], Option[List[Cookie]]].contramap[Opts] { o =>
+      (o.auth, o.headers, o.cookies)
+    }
 
   implicit val optsArbitrary: Arbitrary[Opts] = Arbitrary(
     (for {
-      auth <- Gen.some(authArbitrary.arbitrary)
+      auth    <- Gen.some(authArbitrary.arbitrary)
       headers <- mapArbitrary.arbitrary
       cookies <- Gen.option(Gen.nonEmptyListOf(cookieArbitrary.arbitrary).map(_.toList))
     } yield Opts(auth, headers, cookies)).label("Opts")

--- a/core/shared/src/test/scala/hammock/hi/AuthSpec.scala
+++ b/core/shared/src/test/scala/hammock/hi/AuthSpec.scala
@@ -3,7 +3,7 @@ package hi
 
 import cats._
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 
 class AuthSpec extends AnyWordSpec with Matchers {
 
@@ -45,7 +45,7 @@ class AuthSpec extends AnyWordSpec with Matchers {
     "not equal BasicAuth instances" in {
 
       val authAladdin = Auth.BasicAuth("Aladdin", "OpenSesame")
-      val authSud = Auth.BasicAuth("Sud", "Sabin")
+      val authSud     = Auth.BasicAuth("Sud", "Sabin")
 
       assert(authAladdin != authSud)
     }
@@ -61,7 +61,7 @@ class AuthSpec extends AnyWordSpec with Matchers {
     "not equal OAuth2Bearer instances" in {
 
       val authAladdin = Auth.OAuth2Bearer("tokenAladdin")
-      val authSud = Auth.OAuth2Bearer("tokenSud")
+      val authSud     = Auth.OAuth2Bearer("tokenSud")
 
       assert(authAladdin != authSud)
     }
@@ -77,7 +77,7 @@ class AuthSpec extends AnyWordSpec with Matchers {
     "not equal OAuth2Token instances" in {
 
       val authAladdin = Auth.OAuth2Token("tokenAladdin")
-      val authSud = Auth.OAuth2Token("tokenSud")
+      val authSud     = Auth.OAuth2Token("tokenSud")
 
       assert(authAladdin != authSud)
     }

--- a/core/shared/src/test/scala/hammock/hi/AuthSpec.scala
+++ b/core/shared/src/test/scala/hammock/hi/AuthSpec.scala
@@ -2,9 +2,10 @@ package hammock
 package hi
 
 import cats._
-import org.scalatest._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.Matchers
 
-class AuthSpec extends WordSpec with Matchers {
+class AuthSpec extends AnyWordSpec with Matchers {
 
   import Auth._
 

--- a/core/shared/src/test/scala/hammock/hi/CookieLawTest.scala
+++ b/core/shared/src/test/scala/hammock/hi/CookieLawTest.scala
@@ -1,11 +1,16 @@
 package hammock
 package hi
 
-import cats.tests.CatsSuite
+import cats.instances.int._
+import cats.instances.string._
+import cats.instances.boolean._
+import cats.instances.map._
+import org.scalatest.funsuite.AnyFunSuite
+import org.typelevel.discipline.scalatest.Discipline
 import cats.kernel.laws.discipline.EqTests
 import monocle.law.discipline._
 
-class CookieLawTests extends CatsSuite {
+class CookieLawTests extends AnyFunSuite with Discipline {
 
   import TestInstances._
 

--- a/core/shared/src/test/scala/hammock/hi/CookieSpec.scala
+++ b/core/shared/src/test/scala/hammock/hi/CookieSpec.scala
@@ -4,9 +4,10 @@ package hi
 import java.time.ZonedDateTime
 
 import cats._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CookieSpec extends WordSpec with Matchers {
+class CookieSpec extends AnyWordSpec with Matchers {
 
   "Show[Cookie].show" should {
     "render a simple cookie in the correct format" in {

--- a/core/shared/src/test/scala/hammock/hi/CookieSpec.scala
+++ b/core/shared/src/test/scala/hammock/hi/CookieSpec.scala
@@ -4,7 +4,7 @@ package hi
 import java.time.ZonedDateTime
 
 import cats._
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class CookieSpec extends AnyWordSpec with Matchers {
@@ -26,7 +26,8 @@ class CookieSpec extends AnyWordSpec with Matchers {
         Some("/blog"),
         Some(false),
         Some(true),
-        Some(Cookie.SameSite.Strict))
+        Some(Cookie.SameSite.Strict)
+      )
 
       Show[Cookie].show(cookie) shouldEqual "name=value; Expires=Sat, 04 Jan 2020 17:03:54 GMT; MaxAge=123; Domain=pepegar.com; Path=/blog; Secure=false; HttpOnly=true; SameSite=Strict"
     }

--- a/core/shared/src/test/scala/hammock/hi/DslSpec.scala
+++ b/core/shared/src/test/scala/hammock/hi/DslSpec.scala
@@ -2,9 +2,10 @@ package hammock
 package hi
 
 import cats.implicits._
-import org.scalatest._
+import org.scalatest.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DslSpec extends WordSpec with Matchers {
+class DslSpec extends AnyWordSpec with Matchers {
 
   "`cookies`" should {
     "work when there were no cookies before" in {

--- a/core/shared/src/test/scala/hammock/hi/DslSpec.scala
+++ b/core/shared/src/test/scala/hammock/hi/DslSpec.scala
@@ -2,7 +2,7 @@ package hammock
 package hi
 
 import cats.implicits._
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class DslSpec extends AnyWordSpec with Matchers {

--- a/core/shared/src/test/scala/hammock/hi/OptsLawTests.scala
+++ b/core/shared/src/test/scala/hammock/hi/OptsLawTests.scala
@@ -1,10 +1,15 @@
 package hammock
 package hi
 
-import cats.tests.CatsSuite
+import cats.instances.string._
+import cats.instances.map._
+import cats.instances.option._
+import cats.instances.list._
+import org.scalatest.funsuite.AnyFunSuite
+import org.typelevel.discipline.scalatest.Discipline
 import monocle.law.discipline.{LensTests, OptionalTests}
 
-class OptsLawTests extends CatsSuite {
+class OptsLawTests extends AnyFunSuite with Discipline {
 
   import TestInstances._
 

--- a/docs/src/main/tut/interpreters.md
+++ b/docs/src/main/tut/interpreters.md
@@ -78,6 +78,7 @@ import hammock.akka.AkkaInterpreter._
 implicit val system = ActorSystem("hammock-actor-system")
 implicit val mat = ActorMaterializer()
 implicit val ec = system.dispatcher
+implicit val cs = IO.contextShift(ec)
 implicit val httpExt: HttpExt = Http()
 
 val akkaInterp: InterpTrans[IO] = AkkaInterpreter.instance[IO]

--- a/example-js/src/main/scala/examplejs/Main.scala
+++ b/example-js/src/main/scala/examplejs/Main.scala
@@ -13,12 +13,13 @@ import io.circe.generic.auto._
 import Interpreter._
 
 object Main {
+  implicit val cs = IO.contextShift(global)
+
+  case class Resp(headers: Map[String, String], origin: String, url: String)
+  case class Req(name: String, number: Int)
 
   @JSExportTopLevel("examplejs.Main.main")
   def main(): Unit = {
-
-    case class Resp(headers: Map[String, String], origin: String, url: String)
-    case class Req(name: String, number: Int)
 
     val uri = uri"http://httpbin.org/post"
 

--- a/example-js/src/main/scala/examplejs/Main.scala
+++ b/example-js/src/main/scala/examplejs/Main.scala
@@ -1,6 +1,6 @@
 package examplejs
 
-import scala.scalajs.js.annotation.JSExportTopLevel
+import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 import scala.util._
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalajs.jquery.jQuery
@@ -12,13 +12,14 @@ import hammock.circe.implicits._
 import io.circe.generic.auto._
 import Interpreter._
 
+@JSExportTopLevel("Main")
 object Main {
   implicit val cs = IO.contextShift(global)
 
   case class Resp(headers: Map[String, String], origin: String, url: String)
   case class Req(name: String, number: Int)
 
-  @JSExportTopLevel("examplejs.Main.main")
+  @JSExport
   def main(): Unit = {
 
     val uri = uri"http://httpbin.org/post"

--- a/example/src/main/scala/example/interpret/AkkaInterpExampleMain.scala
+++ b/example/src/main/scala/example/interpret/AkkaInterpExampleMain.scala
@@ -2,7 +2,7 @@ package example.interpret
 import akka.actor.ActorSystem
 import akka.http.scaladsl.{Http, HttpExt}
 import akka.stream.ActorMaterializer
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import example.repr.{GetResp, GetRespWithQueryString, Req, Resp}
 import hammock.{Hammock, Method}
 import hammock.marshalling._
@@ -16,6 +16,7 @@ object AkkaInterpExampleMain extends App {
   implicit val actorSystem: ActorSystem        = ActorSystem()
   implicit val materializer: ActorMaterializer = ActorMaterializer()
   implicit val ec: ExecutionContext            = ExecutionContext.Implicits.global
+  implicit val cs: ContextShift[IO]            = IO.contextShift(ec)
   implicit val client: HttpExt                 = Http(actorSystem)
 
   //GET

--- a/hammock-akka-http/src/main/scala/hammock/akka/AkkaInterpreter.scala
+++ b/hammock-akka-http/src/main/scala/hammock/akka/AkkaInterpreter.scala
@@ -16,7 +16,7 @@ import _root_.akka.stream.ActorMaterializer
 import _root_.akka.util.ByteString
 import cats._
 import cats.data.Kleisli
-import cats.effect.{Async, IO, Sync}
+import cats.effect.{Async, ContextShift, Sync}
 import cats.implicits._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -24,7 +24,7 @@ object AkkaInterpreter {
 
   def apply[F[_]](implicit F: InterpTrans[F]): InterpTrans[F] = F
 
-  implicit def instance[F[_]: Async](
+  implicit def instance[F[_]: Async: ContextShift](
       implicit
       client: HttpExt,
       materializer: ActorMaterializer,
@@ -33,7 +33,7 @@ object AkkaInterpreter {
       override def trans: HttpF ~> F = transK andThen λ[Kleisli[F, HttpExt, ?] ~> F](_.run(client))
     }
 
-  def transK[F[_]: Async](
+  def transK[F[_]: Async: ContextShift](
       implicit materializer: ActorMaterializer,
       executionContext: ExecutionContext): HttpF ~> Kleisli[F, HttpExt, ?] = {
 
@@ -41,7 +41,7 @@ object AkkaInterpreter {
       for {
         akkaRequest    <- mapRequest(req)
         responseFuture <- Sync[F].delay(http.singleRequest(akkaRequest).flatMap(mapResponse))
-        responseF      <- IO.fromFuture(IO(responseFuture)).to[F]
+        responseF      <- Async.fromFuture(Async[F].delay(responseFuture))
       } yield responseF
     }
 

--- a/hammock-akka-http/src/main/scala/hammock/akka/AkkaInterpreter.scala
+++ b/hammock-akka-http/src/main/scala/hammock/akka/AkkaInterpreter.scala
@@ -30,12 +30,12 @@ object AkkaInterpreter {
       materializer: ActorMaterializer,
       executionContext: ExecutionContext) =
     new InterpTrans[F] {
-      override def trans: HttpF ~> F = transK andThen λ[Kleisli[F, HttpExt, ?] ~> F](_.run(client))
+      override def trans: HttpF ~> F = transK andThen λ[Kleisli[F, HttpExt, *] ~> F](_.run(client))
     }
 
   def transK[F[_]: Async: ContextShift](
       implicit materializer: ActorMaterializer,
-      executionContext: ExecutionContext): HttpF ~> Kleisli[F, HttpExt, ?] = {
+      executionContext: ExecutionContext): HttpF ~> Kleisli[F, HttpExt, *] = {
 
     def doReq(req: HttpF[HttpResponse]): Kleisli[F, HttpExt, HttpResponse] = Kleisli { http =>
       for {
@@ -98,7 +98,7 @@ object AkkaInterpreter {
       case StatusCodes.UnprocessableEntity           => Status.UnprocessableEntity
       case StatusCodes.Locked                        => Status.Locked
       case StatusCodes.FailedDependency              => Status.FailedDependency
-      case StatusCodes.UnorderedCollection           => Status.UnorderedCollection
+      case StatusCodes.TooEarly                      => Status.TooEarly
       case StatusCodes.UpgradeRequired               => Status.UpgradeRequired
       case StatusCodes.PreconditionRequired          => Status.PreconditionRequired
       case StatusCodes.TooManyRequests               => Status.TooManyRequests
@@ -128,7 +128,7 @@ object AkkaInterpreter {
       case StatusCodes.Success(x)                    => Status.custom(x)
     }
 
-    λ[HttpF ~> Kleisli[F, HttpExt, ?]] {
+    λ[HttpF ~> Kleisli[F, HttpExt, *]] {
       case req @ (Options(_) | Get(_) | Head(_) | Post(_) | Put(_) | Delete(_) | Trace(_) | Patch(_)) => doReq(req)
     }
   }

--- a/hammock-akka-http/src/test/scala/hammock/akka/AkkaInterpreterSpec.scala
+++ b/hammock-akka-http/src/test/scala/hammock/akka/AkkaInterpreterSpec.scala
@@ -1,27 +1,29 @@
 package hammock
 package akka
 
-import _root_.akka.util.ByteString
 import _root_.akka.actor.ActorSystem
 import _root_.akka.http.scaladsl.HttpExt
+import _root_.akka.http.scaladsl.model.headers.RawHeader
 import _root_.akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpEntity,
+  HttpMethods,
   HttpRequest => AkkaRequest,
   HttpResponse => AkkaResponse,
-  Uri => AkkaUri,
-  HttpEntity,
-  ContentTypes,
-  HttpMethods
+  Uri => AkkaUri
 }
 import _root_.akka.stream.ActorMaterializer
-import _root_.akka.http.scaladsl.model.headers.RawHeader
+import _root_.akka.util.ByteString
 import cats.effect.{ContextShift, IO}
 import cats.free.Free
+import hammock.akka.AkkaInterpreter._
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, Matchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
+
 import scala.concurrent.{ExecutionContext, Future}
-import AkkaInterpreter._
 
 class AkkaInterpreterSpec extends AnyWordSpec with MockitoSugar with Matchers with BeforeAndAfter {
 

--- a/hammock-akka-http/src/test/scala/hammock/akka/AkkaInterpreterSpec.scala
+++ b/hammock-akka-http/src/test/scala/hammock/akka/AkkaInterpreterSpec.scala
@@ -14,19 +14,21 @@ import _root_.akka.http.scaladsl.model.{
 }
 import _root_.akka.stream.ActorMaterializer
 import _root_.akka.http.scaladsl.model.headers.RawHeader
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.free.Free
 import org.mockito.Mockito._
-import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfter, Matchers}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
 import scala.concurrent.{ExecutionContext, Future}
 import AkkaInterpreter._
 
-class AkkaInterpreterSpec extends WordSpec with MockitoSugar with Matchers with BeforeAndAfter {
+class AkkaInterpreterSpec extends AnyWordSpec with MockitoSugar with Matchers with BeforeAndAfter {
 
   implicit val system: ActorSystem    = ActorSystem("test")
   implicit val mat: ActorMaterializer = ActorMaterializer()
   implicit val ec: ExecutionContext   = ExecutionContext.Implicits.global
+  implicit val cs: ContextShift[IO]   = IO.contextShift(ec)
   implicit val client: HttpExt        = mock[HttpExt]
 
   after {

--- a/hammock-apache-http/src/main/scala/hammock/apache/ApacheInterpreter.scala
+++ b/hammock-apache-http/src/main/scala/hammock/apache/ApacheInterpreter.scala
@@ -23,10 +23,10 @@ object ApacheInterpreter {
       implicit
       client: HttpClient = HttpClientBuilder.create().build()): InterpTrans[F] =
     new InterpTrans[F] {
-      def trans: HttpF ~> F = transK andThen λ[Kleisli[F, HttpClient, ?] ~> F](_.run(client))
+      def trans: HttpF ~> F = transK andThen λ[Kleisli[F, HttpClient, *] ~> F](_.run(client))
     }
 
-  def transK[F[_]: Sync]: HttpF ~> Kleisli[F, HttpClient, ?] = {
+  def transK[F[_]: Sync]: HttpF ~> Kleisli[F, HttpClient, *] = {
 
     def responseToEntity(response: ApacheResponse): F[Entity] = Sync[F].delay {
       Option(response.getEntity) // getEntity can return null
@@ -48,7 +48,7 @@ object ApacheInterpreter {
       } yield HttpResponse(status, responseHeaders, entity)
     }
 
-    λ[HttpF ~> Kleisli[F, HttpClient, ?]] {
+    λ[HttpF ~> Kleisli[F, HttpClient, *]] {
       case req: Options => doReq(req)
       case req: Get     => doReq(req)
       case req: Head    => doReq(req)

--- a/hammock-apache-http/src/test/scala/hammock/apache/ApacheInterpreterSpec.scala
+++ b/hammock-apache-http/src/test/scala/hammock/apache/ApacheInterpreterSpec.scala
@@ -48,7 +48,7 @@ class ApacheInterpreterSpec extends AnyWordSpec with MockitoSugar with BeforeAnd
           when(client.execute(any[HttpUriRequest])).thenReturn(httpResponse)
 
           val op           = operation(Uri(), Map())
-          val k            = op.foldMap[Kleisli[IO, HttpClient, ?]](transK)
+          val k            = op.foldMap[Kleisli[IO, HttpClient, *]](transK)
           val transKResult = k.run(client).unsafeRunSync
           val transResult  = (op foldMap ApacheInterpreter[IO].trans).unsafeRunSync
 

--- a/hammock-asynchttpclient/src/main/scala/hammock/asynchttpclient/AsyncHttpClientInterpreter.scala
+++ b/hammock-asynchttpclient/src/main/scala/hammock/asynchttpclient/AsyncHttpClientInterpreter.scala
@@ -17,10 +17,10 @@ object AsyncHttpClientInterpreter {
   implicit def instance[F[_]: Async](
       implicit client: AsyncHttpClient = new DefaultAsyncHttpClient()
   ): InterpTrans[F] = new InterpTrans[F] {
-    override def trans: HttpF ~> F = transK andThen λ[Kleisli[F, AsyncHttpClient, ?] ~> F](_.run(client))
+    override def trans: HttpF ~> F = transK andThen λ[Kleisli[F, AsyncHttpClient, *] ~> F](_.run(client))
   }
 
-  def transK[F[_]: Async]: HttpF ~> Kleisli[F, AsyncHttpClient, ?] = {
+  def transK[F[_]: Async]: HttpF ~> Kleisli[F, AsyncHttpClient, *] = {
 
     def toF[A](future: jc.Future[A]): F[A] =
       Async[F].async(_(Try(future.get) match {
@@ -28,7 +28,7 @@ object AsyncHttpClientInterpreter {
         case Success(a)   => Right(a)
       }))
 
-    λ[HttpF ~> Kleisli[F, AsyncHttpClient, ?]] {
+    λ[HttpF ~> Kleisli[F, AsyncHttpClient, *]] {
       case reqF @ (Get(_) | Options(_) | Delete(_) | Head(_) | Options(_) | Trace(_) | Post(_) | Put(_) | Patch(_)) =>
         Kleisli { implicit client =>
           for {

--- a/hammock-asynchttpclient/src/test/scala/hammock/asynchttpclient/AsyncHttpClientInterpreterSpec.scala
+++ b/hammock-asynchttpclient/src/test/scala/hammock/asynchttpclient/AsyncHttpClientInterpreterSpec.scala
@@ -3,7 +3,7 @@ package asynchttpclient
 
 import cats.implicits._
 import cats.effect._
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.asynchttpclient._
 import io.netty.handler.codec.http.{DefaultHttpHeaders, HttpHeaders}

--- a/hammock-asynchttpclient/src/test/scala/hammock/asynchttpclient/AsyncHttpClientInterpreterSpec.scala
+++ b/hammock-asynchttpclient/src/test/scala/hammock/asynchttpclient/AsyncHttpClientInterpreterSpec.scala
@@ -3,15 +3,16 @@ package asynchttpclient
 
 import cats.implicits._
 import cats.effect._
-import org.scalatest._
+import org.scalatest.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.asynchttpclient._
 import io.netty.handler.codec.http.{DefaultHttpHeaders, HttpHeaders}
 import io.netty.handler.codec.http.cookie.Cookie
-import org.scalatest.mockito._
+import org.scalatestplus.mockito._
 import AsyncHttpClientInterpreter._
 import scala.collection.JavaConverters._
 
-class AsyncHttpClientInterpreterSpec extends WordSpec with Matchers with MockitoSugar {
+class AsyncHttpClientInterpreterSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
   implicit val client: AsyncHttpClient = new DefaultAsyncHttpClient()
 

--- a/hammock-circe/src/test/scala/hammock/circe/CirceCodecSpec.scala
+++ b/hammock-circe/src/test/scala/hammock/circe/CirceCodecSpec.scala
@@ -3,7 +3,7 @@ package circe
 
 import io.circe.generic.auto._
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class CirceCodecSpec extends AnyWordSpec with Matchers {

--- a/hammock-circe/src/test/scala/hammock/circe/CirceCodecSpec.scala
+++ b/hammock-circe/src/test/scala/hammock/circe/CirceCodecSpec.scala
@@ -3,9 +3,10 @@ package circe
 
 import io.circe.generic.auto._
 
-import org.scalatest._
+import org.scalatest.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CirceCodecSpec extends WordSpec with Matchers {
+class CirceCodecSpec extends AnyWordSpec with Matchers {
   case class Dummy(a: Int, b: String)
   import implicits._
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("org.scoverage"             % "sbt-scoverage"            % "1.6.0")
 addSbtPlugin("com.47deg"                 % "sbt-microsites"           % "0.9.1")
 addSbtPlugin("com.github.gseitz"         % "sbt-release"              % "1.0.11")
-addSbtPlugin("org.scala-js"              % "sbt-scalajs"              % "0.6.22")
+addSbtPlugin("org.scala-js"              % "sbt-scalajs"              % "0.6.29")
 addSbtPlugin("org.portable-scala"        % "sbt-crossproject"         % "0.6.1")
 addSbtPlugin("org.portable-scala"        % "sbt-scalajs-crossproject" % "0.6.1")
 addSbtPlugin("com.lucidchart"            % "sbt-scalafmt"             % "1.16")


### PR DESCRIPTION
- Update cats-effect and downstream dependencies.
- Don't support 2.11 anymore.